### PR TITLE
fix: resolve cyclic dependencies

### DIFF
--- a/src/osp/IOneStepProver.sol
+++ b/src/osp/IOneStepProver.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.0;
 import "../state/Machine.sol";
 import "../state/Module.sol";
 import "../state/Instructions.sol";
+import "../state/GlobalState.sol";
 import "../bridge/ISequencerInbox.sol";
 import "../bridge/IBridge.sol";
 

--- a/src/osp/OneStepProverHostIo.sol
+++ b/src/osp/OneStepProverHostIo.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.0;
 import "../state/Value.sol";
 import "../state/Machine.sol";
 import "../state/Deserialize.sol";
+import "../state/ModuleMemory.sol";
 import "./IOneStepProver.sol";
 import "../bridge/Messages.sol";
 import "../bridge/IBridge.sol";

--- a/src/osp/OneStepProverMemory.sol
+++ b/src/osp/OneStepProverMemory.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.0;
 import "../state/Value.sol";
 import "../state/Machine.sol";
 import "../state/Deserialize.sol";
+import "../state/ModuleMemory.sol";
 import "./IOneStepProver.sol";
 
 contract OneStepProverMemory is IOneStepProver {

--- a/src/rollup/Config.sol
+++ b/src/rollup/Config.sol
@@ -1,0 +1,43 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "../state/GlobalState.sol";
+import "../state/Machine.sol";
+import "../bridge/ISequencerInbox.sol";
+import "../bridge/IBridge.sol";
+import "../bridge/IOutbox.sol";
+import "../bridge/IInbox.sol";
+import "./IRollupEventInbox.sol";
+import "./IRollupLogic.sol";
+import "../challenge/IChallengeManager.sol";
+
+struct Config {
+    uint64 confirmPeriodBlocks;
+    uint64 extraChallengeTimeBlocks;
+    address stakeToken;
+    uint256 baseStake;
+    bytes32 wasmModuleRoot;
+    address owner;
+    address loserStakeEscrow;
+    uint256 chainId;
+    string chainConfig;
+    uint64 genesisBlockNum;
+    ISequencerInbox.MaxTimeVariation sequencerInboxMaxTimeVariation;
+}
+
+struct ContractDependencies {
+    IBridge bridge;
+    ISequencerInbox sequencerInbox;
+    IInbox inbox;
+    IOutbox outbox;
+    IRollupEventInbox rollupEventInbox;
+    IChallengeManager challengeManager;
+    address rollupAdminLogic;
+    IRollupUser rollupUserLogic;
+    // misc contracts that are useful when interacting with the rollup
+    address validatorUtils;
+    address validatorWalletCreator;
+}

--- a/src/rollup/IRollupAdmin.sol
+++ b/src/rollup/IRollupAdmin.sol
@@ -1,0 +1,138 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "./IRollupCore.sol";
+import "../bridge/ISequencerInbox.sol";
+import "../bridge/IOutbox.sol";
+import "../bridge/IOwnable.sol";
+import "./Config.sol";
+
+interface IRollupAdmin {
+    event OwnerFunctionCalled(uint256 indexed id);
+
+    function initialize(Config calldata config, ContractDependencies calldata connectedContracts)
+        external;
+
+    /**
+     * @notice Add a contract authorized to put messages into this rollup's inbox
+     * @param _outbox Outbox contract to add
+     */
+    function setOutbox(IOutbox _outbox) external;
+
+    /**
+     * @notice Disable an old outbox from interacting with the bridge
+     * @param _outbox Outbox contract to remove
+     */
+    function removeOldOutbox(address _outbox) external;
+
+    /**
+     * @notice Enable or disable an inbox contract
+     * @param _inbox Inbox contract to add or remove
+     * @param _enabled New status of inbox
+     */
+    function setDelayedInbox(address _inbox, bool _enabled) external;
+
+    /**
+     * @notice Pause interaction with the rollup contract
+     */
+    function pause() external;
+
+    /**
+     * @notice Resume interaction with the rollup contract
+     */
+    function resume() external;
+
+    /**
+     * @notice Set the addresses of the validator whitelist
+     * @dev It is expected that both arrays are same length, and validator at
+     * position i corresponds to the value at position i
+     * @param _validator addresses to set in the whitelist
+     * @param _val value to set in the whitelist for corresponding address
+     */
+    function setValidator(address[] memory _validator, bool[] memory _val) external;
+
+    /**
+     * @notice Set a new owner address for the rollup proxy
+     * @param newOwner address of new rollup owner
+     */
+    function setOwner(address newOwner) external;
+
+    /**
+     * @notice Set minimum assertion period for the rollup
+     * @param newPeriod new minimum period for assertions
+     */
+    function setMinimumAssertionPeriod(uint256 newPeriod) external;
+
+    /**
+     * @notice Set number of blocks until a node is considered confirmed
+     * @param newConfirmPeriod new number of blocks until a node is confirmed
+     */
+    function setConfirmPeriodBlocks(uint64 newConfirmPeriod) external;
+
+    /**
+     * @notice Set number of extra blocks after a challenge
+     * @param newExtraTimeBlocks new number of blocks
+     */
+    function setExtraChallengeTimeBlocks(uint64 newExtraTimeBlocks) external;
+
+    /**
+     * @notice Set base stake required for an assertion
+     * @param newBaseStake maximum avmgas to be used per block
+     */
+    function setBaseStake(uint256 newBaseStake) external;
+
+    /**
+     * @notice Set the token used for stake, where address(0) == eth
+     * @dev Before changing the base stake token, you might need to change the
+     * implementation of the Rollup User logic!
+     * @param newStakeToken address of token used for staking
+     */
+    function setStakeToken(address newStakeToken) external;
+
+    /**
+     * @notice Upgrades the implementation of a beacon controlled by the rollup
+     * @param beacon address of beacon to be upgraded
+     * @param newImplementation new address of implementation
+     */
+    function upgradeBeacon(address beacon, address newImplementation) external;
+
+    function forceResolveChallenge(address[] memory stackerA, address[] memory stackerB) external;
+
+    function forceRefundStaker(address[] memory stacker) external;
+
+    function forceCreateNode(
+        uint64 prevNode,
+        uint256 prevNodeInboxMaxCount,
+        Assertion memory assertion,
+        bytes32 expectedNodeHash
+    ) external;
+
+    function forceConfirmNode(
+        uint64 nodeNum,
+        bytes32 blockHash,
+        bytes32 sendRoot
+    ) external;
+
+    function setLoserStakeEscrow(address newLoserStakerEscrow) external;
+
+    /**
+     * @notice Set the proving WASM module root
+     * @param newWasmModuleRoot new module root
+     */
+    function setWasmModuleRoot(bytes32 newWasmModuleRoot) external;
+
+    /**
+     * @notice set a new sequencer inbox contract
+     * @param _sequencerInbox new address of sequencer inbox
+     */
+    function setSequencerInbox(address _sequencerInbox) external;
+
+    /**
+     * @notice set the validatorWhitelistDisabled flag
+     * @param _validatorWhitelistDisabled new value of validatorWhitelistDisabled, i.e. true = disabled
+     */
+    function setValidatorWhitelistDisabled(bool _validatorWhitelistDisabled) external;
+}

--- a/src/rollup/IRollupCore.sol
+++ b/src/rollup/IRollupCore.sol
@@ -5,7 +5,11 @@
 pragma solidity ^0.8.0;
 
 import "./Node.sol";
-import "./RollupLib.sol";
+import "../bridge/IBridge.sol";
+import "../bridge/IOutbox.sol";
+import "../bridge/IInbox.sol";
+import "./IRollupEventInbox.sol";
+import "../challenge/IChallengeManager.sol";
 
 interface IRollupCore {
     struct Staker {
@@ -24,7 +28,7 @@ interface IRollupCore {
         bytes32 indexed parentNodeHash,
         bytes32 indexed nodeHash,
         bytes32 executionHash,
-        RollupLib.Assertion assertion,
+        Assertion assertion,
         bytes32 afterInboxBatchAcc,
         bytes32 wasmModuleRoot,
         uint256 inboxMaxCount

--- a/src/rollup/IRollupLogic.sol
+++ b/src/rollup/IRollupLogic.sol
@@ -4,7 +4,6 @@
 
 pragma solidity ^0.8.0;
 
-import "./RollupLib.sol";
 import "./IRollupCore.sol";
 import "../bridge/ISequencerInbox.sol";
 import "../bridge/IOutbox.sol";
@@ -28,7 +27,7 @@ interface IRollupUserAbs is IRollupCore, IOwnable {
     function stakeOnExistingNode(uint64 nodeNum, bytes32 nodeHash) external;
 
     function stakeOnNewNode(
-        RollupLib.Assertion memory assertion,
+        Assertion memory assertion,
         bytes32 expectedNodeHash,
         uint256 prevNodeInboxMaxCount
     ) external;
@@ -75,7 +74,7 @@ interface IRollupUser is IRollupUserAbs {
     function newStakeOnExistingNode(uint64 nodeNum, bytes32 nodeHash) external payable;
 
     function newStakeOnNewNode(
-        RollupLib.Assertion calldata assertion,
+        Assertion calldata assertion,
         bytes32 expectedNodeHash,
         uint256 prevNodeInboxMaxCount
     ) external payable;
@@ -92,137 +91,10 @@ interface IRollupUserERC20 is IRollupUserAbs {
 
     function newStakeOnNewNode(
         uint256 tokenAmount,
-        RollupLib.Assertion calldata assertion,
+        Assertion calldata assertion,
         bytes32 expectedNodeHash,
         uint256 prevNodeInboxMaxCount
     ) external;
 
     function addToDeposit(address stakerAddress, uint256 tokenAmount) external;
-}
-
-interface IRollupAdmin {
-    event OwnerFunctionCalled(uint256 indexed id);
-
-    function initialize(Config calldata config, ContractDependencies calldata connectedContracts)
-        external;
-
-    /**
-     * @notice Add a contract authorized to put messages into this rollup's inbox
-     * @param _outbox Outbox contract to add
-     */
-    function setOutbox(IOutbox _outbox) external;
-
-    /**
-     * @notice Disable an old outbox from interacting with the bridge
-     * @param _outbox Outbox contract to remove
-     */
-    function removeOldOutbox(address _outbox) external;
-
-    /**
-     * @notice Enable or disable an inbox contract
-     * @param _inbox Inbox contract to add or remove
-     * @param _enabled New status of inbox
-     */
-    function setDelayedInbox(address _inbox, bool _enabled) external;
-
-    /**
-     * @notice Pause interaction with the rollup contract
-     */
-    function pause() external;
-
-    /**
-     * @notice Resume interaction with the rollup contract
-     */
-    function resume() external;
-
-    /**
-     * @notice Set the addresses of the validator whitelist
-     * @dev It is expected that both arrays are same length, and validator at
-     * position i corresponds to the value at position i
-     * @param _validator addresses to set in the whitelist
-     * @param _val value to set in the whitelist for corresponding address
-     */
-    function setValidator(address[] memory _validator, bool[] memory _val) external;
-
-    /**
-     * @notice Set a new owner address for the rollup proxy
-     * @param newOwner address of new rollup owner
-     */
-    function setOwner(address newOwner) external;
-
-    /**
-     * @notice Set minimum assertion period for the rollup
-     * @param newPeriod new minimum period for assertions
-     */
-    function setMinimumAssertionPeriod(uint256 newPeriod) external;
-
-    /**
-     * @notice Set number of blocks until a node is considered confirmed
-     * @param newConfirmPeriod new number of blocks until a node is confirmed
-     */
-    function setConfirmPeriodBlocks(uint64 newConfirmPeriod) external;
-
-    /**
-     * @notice Set number of extra blocks after a challenge
-     * @param newExtraTimeBlocks new number of blocks
-     */
-    function setExtraChallengeTimeBlocks(uint64 newExtraTimeBlocks) external;
-
-    /**
-     * @notice Set base stake required for an assertion
-     * @param newBaseStake maximum avmgas to be used per block
-     */
-    function setBaseStake(uint256 newBaseStake) external;
-
-    /**
-     * @notice Set the token used for stake, where address(0) == eth
-     * @dev Before changing the base stake token, you might need to change the
-     * implementation of the Rollup User logic!
-     * @param newStakeToken address of token used for staking
-     */
-    function setStakeToken(address newStakeToken) external;
-
-    /**
-     * @notice Upgrades the implementation of a beacon controlled by the rollup
-     * @param beacon address of beacon to be upgraded
-     * @param newImplementation new address of implementation
-     */
-    function upgradeBeacon(address beacon, address newImplementation) external;
-
-    function forceResolveChallenge(address[] memory stackerA, address[] memory stackerB) external;
-
-    function forceRefundStaker(address[] memory stacker) external;
-
-    function forceCreateNode(
-        uint64 prevNode,
-        uint256 prevNodeInboxMaxCount,
-        RollupLib.Assertion memory assertion,
-        bytes32 expectedNodeHash
-    ) external;
-
-    function forceConfirmNode(
-        uint64 nodeNum,
-        bytes32 blockHash,
-        bytes32 sendRoot
-    ) external;
-
-    function setLoserStakeEscrow(address newLoserStakerEscrow) external;
-
-    /**
-     * @notice Set the proving WASM module root
-     * @param newWasmModuleRoot new module root
-     */
-    function setWasmModuleRoot(bytes32 newWasmModuleRoot) external;
-
-    /**
-     * @notice set a new sequencer inbox contract
-     * @param _sequencerInbox new address of sequencer inbox
-     */
-    function setSequencerInbox(address _sequencerInbox) external;
-
-    /**
-     * @notice set the validatorWhitelistDisabled flag
-     * @param _validatorWhitelistDisabled new value of validatorWhitelistDisabled, i.e. true = disabled
-     */
-    function setValidatorWhitelistDisabled(bool _validatorWhitelistDisabled) external;
 }

--- a/src/rollup/Node.sol
+++ b/src/rollup/Node.sol
@@ -4,6 +4,20 @@
 
 pragma solidity ^0.8.0;
 
+import "../state/GlobalState.sol";
+import "../state/Machine.sol";
+
+struct ExecutionState {
+    GlobalState globalState;
+    MachineStatus machineStatus;
+}
+
+struct Assertion {
+    ExecutionState beforeState;
+    ExecutionState afterState;
+    uint64 numBlocks;
+}
+
 struct Node {
     // Hash of the state of the chain as of this node
     bytes32 stateHash;

--- a/src/rollup/RollupAdminLogic.sol
+++ b/src/rollup/RollupAdminLogic.sol
@@ -4,7 +4,8 @@
 
 pragma solidity ^0.8.0;
 
-import {IRollupAdmin, IRollupUser} from "./IRollupLogic.sol";
+import "./IRollupAdmin.sol";
+import "./IRollupLogic.sol";
 import "./RollupCore.sol";
 import "../bridge/IOutbox.sol";
 import "../bridge/ISequencerInbox.sol";
@@ -76,7 +77,7 @@ contract RollupAdminLogic is RollupCore, IRollupAdmin, DoubleLogicUUPSUpgradeabl
     function createInitialNode() private view returns (Node memory) {
         GlobalState memory emptyGlobalState;
         bytes32 state = RollupLib.stateHashMem(
-            RollupLib.ExecutionState(emptyGlobalState, MachineStatus.FINISHED),
+            ExecutionState(emptyGlobalState, MachineStatus.FINISHED),
             1 // inboxMaxCount - force the first assertion to read a message
         );
         return
@@ -285,7 +286,7 @@ contract RollupAdminLogic is RollupCore, IRollupAdmin, DoubleLogicUUPSUpgradeabl
     function forceCreateNode(
         uint64 prevNode,
         uint256 prevNodeInboxMaxCount,
-        RollupLib.Assertion calldata assertion,
+        Assertion calldata assertion,
         bytes32 expectedNodeHash
     ) external override whenPaused {
         require(prevNode == latestConfirmed(), "ONLY_LATEST_CONFIRMED");
@@ -340,10 +341,7 @@ contract RollupAdminLogic is RollupCore, IRollupAdmin, DoubleLogicUUPSUpgradeabl
         emit OwnerFunctionCalled(28);
     }
 
-    function createNitroMigrationGenesis(RollupLib.Assertion calldata assertion)
-        external
-        whenPaused
-    {
+    function createNitroMigrationGenesis(Assertion calldata assertion) external whenPaused {
         bytes32 expectedSendRoot = bytes32(0);
         uint64 expectedInboxCount = 1;
 

--- a/src/rollup/RollupCore.sol
+++ b/src/rollup/RollupCore.sol
@@ -7,7 +7,6 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 
 import "./Node.sol";
-import "./IRollupCore.sol";
 import "./RollupLib.sol";
 import "./IRollupEventInbox.sol";
 import "./IRollupCore.sol";
@@ -568,7 +567,7 @@ abstract contract RollupCore is IRollupCore, PausableUpgradeable {
     }
 
     function createNewNode(
-        RollupLib.Assertion calldata assertion,
+        Assertion calldata assertion,
         uint64 prevNodeNum,
         uint256 prevNodeInboxMaxCount,
         bytes32 expectedNodeHash

--- a/src/rollup/RollupCreator.sol
+++ b/src/rollup/RollupCreator.sol
@@ -113,7 +113,7 @@ contract RollupCreator is Ownable {
                 outbox: frame.outbox,
                 rollupEventInbox: frame.rollupEventInbox,
                 challengeManager: challengeManager,
-                rollupAdminLogic: rollupAdminLogic,
+                rollupAdminLogic: address(rollupAdminLogic),
                 rollupUserLogic: rollupUserLogic,
                 validatorUtils: validatorUtils,
                 validatorWalletCreator: validatorWalletCreator

--- a/src/rollup/RollupLib.sol
+++ b/src/rollup/RollupLib.sol
@@ -12,44 +12,11 @@ import "../bridge/ISequencerInbox.sol";
 import "../bridge/IBridge.sol";
 import "../bridge/IOutbox.sol";
 import "../bridge/IInbox.sol";
+import "./Node.sol";
 import "./IRollupEventInbox.sol";
-import "./IRollupLogic.sol";
-
-struct Config {
-    uint64 confirmPeriodBlocks;
-    uint64 extraChallengeTimeBlocks;
-    address stakeToken;
-    uint256 baseStake;
-    bytes32 wasmModuleRoot;
-    address owner;
-    address loserStakeEscrow;
-    uint256 chainId;
-    string chainConfig;
-    uint64 genesisBlockNum;
-    ISequencerInbox.MaxTimeVariation sequencerInboxMaxTimeVariation;
-}
-
-struct ContractDependencies {
-    IBridge bridge;
-    ISequencerInbox sequencerInbox;
-    IInbox inbox;
-    IOutbox outbox;
-    IRollupEventInbox rollupEventInbox;
-    IChallengeManager challengeManager;
-    IRollupAdmin rollupAdminLogic;
-    IRollupUser rollupUserLogic;
-    // misc contracts that are useful when interacting with the rollup
-    address validatorUtils;
-    address validatorWalletCreator;
-}
 
 library RollupLib {
     using GlobalStateLib for GlobalState;
-
-    struct ExecutionState {
-        GlobalState globalState;
-        MachineStatus machineStatus;
-    }
 
     function stateHash(ExecutionState calldata execState, uint256 inboxMaxCount)
         internal
@@ -80,12 +47,6 @@ library RollupLib {
                     execState.machineStatus
                 )
             );
-    }
-
-    struct Assertion {
-        ExecutionState beforeState;
-        ExecutionState afterState;
-        uint64 numBlocks;
     }
 
     function executionHash(Assertion memory assertion) internal pure returns (bytes32) {

--- a/src/rollup/RollupProxy.sol
+++ b/src/rollup/RollupProxy.sol
@@ -5,7 +5,8 @@
 pragma solidity ^0.8.0;
 
 import "../libraries/AdminFallbackProxy.sol";
-import "./IRollupLogic.sol";
+import "./IRollupAdmin.sol";
+import "./Config.sol";
 
 contract RollupProxy is AdminFallbackProxy {
     constructor(Config memory config, ContractDependencies memory connectedContracts)

--- a/src/rollup/RollupUserLogic.sol
+++ b/src/rollup/RollupUserLogic.sol
@@ -9,6 +9,8 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import {IRollupUser} from "./IRollupLogic.sol";
 import "../libraries/UUPSNotUpgradeable.sol";
 import "./RollupCore.sol";
+import "./IRollupLogic.sol";
+
 import {ETH_POS_BLOCK_TIME} from "../libraries/Constants.sol";
 
 abstract contract AbsRollupUserLogic is
@@ -189,7 +191,7 @@ abstract contract AbsRollupUserLogic is
      * @param expectedNodeHash The hash of the node being created (protects against reorgs)
      */
     function stakeOnNewNode(
-        RollupLib.Assertion calldata assertion,
+        Assertion calldata assertion,
         bytes32 expectedNodeHash,
         uint256 prevNodeInboxMaxCount
     ) public onlyValidator whenNotPaused {
@@ -632,7 +634,7 @@ contract RollupUserLogic is AbsRollupUserLogic, IRollupUser {
      * @param prevNodeInboxMaxCount Total of messages in the inbox as of the previous node
      */
     function newStakeOnNewNode(
-        RollupLib.Assertion calldata assertion,
+        Assertion calldata assertion,
         bytes32 expectedNodeHash,
         uint256 prevNodeInboxMaxCount
     ) external payable override {
@@ -701,7 +703,7 @@ contract ERC20RollupUserLogic is AbsRollupUserLogic, IRollupUserERC20 {
      */
     function newStakeOnNewNode(
         uint256 tokenAmount,
-        RollupLib.Assertion calldata assertion,
+        Assertion calldata assertion,
         bytes32 expectedNodeHash,
         uint256 prevNodeInboxMaxCount
     ) external override {

--- a/src/rollup/ValidatorUtils.sol
+++ b/src/rollup/ValidatorUtils.sol
@@ -8,6 +8,7 @@ pragma experimental ABIEncoderV2;
 
 import "../rollup/IRollupCore.sol";
 import "../challenge/IChallengeManager.sol";
+import "./IRollupLogic.sol";
 
 import {NO_CHAL_INDEX} from "../libraries/Constants.sol";
 

--- a/src/state/Deserialize.sol
+++ b/src/state/Deserialize.sol
@@ -10,7 +10,7 @@ import "./Machine.sol";
 import "./Instructions.sol";
 import "./StackFrame.sol";
 import "./MerkleProof.sol";
-import "./ModuleMemory.sol";
+import "./ModuleMemoryCompact.sol";
 import "./Module.sol";
 import "./GlobalState.sol";
 

--- a/src/state/Module.sol
+++ b/src/state/Module.sol
@@ -4,7 +4,7 @@
 
 pragma solidity ^0.8.0;
 
-import "./ModuleMemory.sol";
+import "./ModuleMemoryCompact.sol";
 
 struct Module {
     bytes32 globalsMerkleRoot;
@@ -15,7 +15,7 @@ struct Module {
 }
 
 library ModuleLib {
-    using ModuleMemoryLib for ModuleMemory;
+    using ModuleMemoryCompactLib for ModuleMemory;
 
     function hash(Module memory mod) internal pure returns (bytes32) {
         return

--- a/src/state/ModuleMemory.sol
+++ b/src/state/ModuleMemory.sol
@@ -6,18 +6,13 @@ pragma solidity ^0.8.0;
 
 import "./MerkleProof.sol";
 import "./Deserialize.sol";
-
-struct ModuleMemory {
-    uint64 size;
-    uint64 maxSize;
-    bytes32 merkleRoot;
-}
+import "./ModuleMemoryCompact.sol";
 
 library ModuleMemoryLib {
     using MerkleProofLib for MerkleProof;
 
     function hash(ModuleMemory memory mem) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked("Memory:", mem.size, mem.maxSize, mem.merkleRoot));
+        return ModuleMemoryCompactLib.hash(mem);
     }
 
     function proveLeaf(

--- a/src/state/ModuleMemoryCompact.sol
+++ b/src/state/ModuleMemoryCompact.sol
@@ -1,0 +1,17 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/nitro/blob/master/LICENSE
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+struct ModuleMemory {
+    uint64 size;
+    uint64 maxSize;
+    bytes32 merkleRoot;
+}
+
+library ModuleMemoryCompactLib {
+    function hash(ModuleMemory memory mem) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked("Memory:", mem.size, mem.maxSize, mem.merkleRoot));
+    }
+}

--- a/test/contract/arbRollup.spec.ts
+++ b/test/contract/arbRollup.spec.ts
@@ -50,9 +50,8 @@ import {
   forceCreateNode,
   assertionEquals,
 } from './common/rolluplib'
-import { RollupLib } from '../../build/types/src/rollup/RollupUserLogic.sol/RollupUserLogic'
-type AssertionStruct = RollupLib.AssertionStruct
-type ExecutionStateStruct = RollupLib.ExecutionStateStruct
+import { AssertionStruct } from '../../build/types/src/rollup/RollupCore'
+import { ExecutionStateStruct } from '../../build/types/src/rollup/RollupCore'
 import { keccak256 } from 'ethers/lib/utils'
 import {
   ConfigStruct,

--- a/test/contract/common/rolluplib.ts
+++ b/test/contract/common/rolluplib.ts
@@ -10,12 +10,9 @@ import {
   RollupAdminLogic,
   SequencerInbox,
 } from '../../../build/types'
-import {
-  RollupLib,
-  NodeCreatedEvent,
-} from '../../../build/types/src/rollup/RollupUserLogic.sol/RollupUserLogic'
-type AssertionStruct = RollupLib.AssertionStruct
-type ExecutionStateStruct = RollupLib.ExecutionStateStruct
+import { NodeCreatedEvent } from '../../../build/types/src/rollup/RollupUserLogic.sol/RollupUserLogic'
+import { AssertionStruct } from '../../../build/types/src/rollup/RollupCore'
+import { ExecutionStateStruct } from '../../../build/types/src/rollup/RollupCore'
 import { blockStateHash, hashChallengeState } from './challengeLib'
 import * as globalStateLib from './globalStateLib'
 import { constants } from 'ethers'


### PR DESCRIPTION
This PR resolved the 2 cyclic dependencies in `state` and `rollup` respectively

A quick check to verify there are no cyclic dependencies is to run:
```
yarn hardhat flatten src/rollup/RollupCreator.sol
yarn hardhat flatten src/state/MerkleProof.sol
```
hardhat will throw if there is circular import
```
Error HH603: Hardhat flatten doesn't support cyclic dependencies.
```

