### PR TITLE
chore(ISequencerInbox): Add Missing views

### DIFF
--- a/src/bridge/ISequencerInbox.sol
+++ b/src/bridge/ISequencerInbox.sol
@@ -76,9 +76,9 @@ interface ISequencerInbox is IDelayedMessageProvider {
         uint64 creationBlock;
     }
 
-    // https://github.com/ethereum/solidity/issues/11826
-    // function maxTimeVariation() external view returns (MaxTimeVariation calldata);
-    // function dasKeySetInfo(bytes32) external view returns (DasKeySetInfo calldata);
+    function maxTimeVariation() external view returns (uint256, uint256, uint256, uint256);
+
+    function dasKeySetInfo(bytes32) external view returns (bool, uint64);
 
     /// @notice Remove force inclusion delay after a L1 chainId fork
     function removeDelayAfterFork() external;

--- a/src/bridge/ISequencerInbox.sol
+++ b/src/bridge/ISequencerInbox.sol
@@ -76,7 +76,15 @@ interface ISequencerInbox is IDelayedMessageProvider {
         uint64 creationBlock;
     }
 
-    function maxTimeVariation() external view returns (uint256, uint256, uint256, uint256);
+    function maxTimeVariation()
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256,
+            uint256
+        );
 
     function dasKeySetInfo(bytes32) external view returns (bool, uint64);
 


### PR DESCRIPTION
The external view function stubs are missing from the ISequencerInbox interface for

- maxTimeVariation
- dasKeySetInfo

In solidity, public struct [autogenerate](https://docs.soliditylang.org/en/v0.8.20/contracts.html#visibility-and-getters) public views returning the struct members in order (excluding arrays and mappings). In the case of dasKeySetInfo which is a mapping, the view takes a key parameter of the same type as the mapping.

This PR adds the missing stubs.