### PR TITLE
chore(precompiles): ArbGasInfo interface comment update

### DIFF
--- a/src/precompiles/ArbAddressTable.sol
+++ b/src/precompiles/ArbAddressTable.sol
@@ -29,32 +29,32 @@ interface ArbAddressTable {
      * @param offset offset of target address
      * @return resulting address and updated offset into the buffer (revert if buffer is too short)
      */
-    function decompress(bytes calldata buf, uint256 offset)
+    function decompress(bytes calldata buf, uint64 offset)
         external
         view
-        returns (address, uint256);
+        returns (address, uint64);
 
     /**
      * @param addr address to lookup
      * @return index of an address in the address table (revert if address isn't in the table)
      */
-    function lookup(address addr) external view returns (uint256);
+    function lookup(address addr) external view returns (uint64);
 
     /**
      * @param index index to lookup address
      * @return address at a given index in address table (revert if index is beyond end of table)
      */
-    function lookupIndex(uint256 index) external view returns (address);
+    function lookupIndex(uint64 index) external view returns (address);
 
     /**
      * @notice Register an address in the address table
      * @param addr address to register
      * @return index of the address (existing index, or newly created index if not already registered)
      */
-    function register(address addr) external returns (uint256);
+    function register(address addr) external returns (uint64);
 
     /**
      * @return size of address table (= first unused index)
      */
-    function size() external view returns (uint256);
+    function size() external view returns (uint64);
 }

--- a/src/precompiles/ArbGasInfo.sol
+++ b/src/precompiles/ArbGasInfo.sol
@@ -75,8 +75,8 @@ interface ArbGasInfo {
             uint256
         );
 
-    /// @notice Get the gas accounting parameters. `gasPoolMax` is always zero, as the exponential pricing model has no such notion.
-    /// @return (speedLimitPerSecond, gasPoolMax, maxTxGasLimit)
+    /// @notice Get the gas accounting parameters. `maxTxGasLimit` is always the same as perBlockGasLimit.
+    /// @return (speedLimitPerSecond, perBlockGasLimit, maxTxGasLimit)
     function getGasAccountingParams()
         external
         view


### PR DESCRIPTION
The comment about returning zero for the second return param is false and misleading.

https://github.com/OffchainLabs/nitro/blob/ce5eb97644e03586175d0b4b3f6ed9966ac42f70/precompiles/ArbGasInfo.go#L146

The precompile returns the perBlockGasLimit which is the same as the maxTxGasLimit.