### PR TITLE
feat(SequencerInbox): gas optimization

### DIFF
--- a/src/bridge/ISequencerInbox.sol
+++ b/src/bridge/ISequencerInbox.sol
@@ -12,10 +12,10 @@ import "./IBridge.sol";
 
 interface ISequencerInbox is IDelayedMessageProvider {
     struct MaxTimeVariation {
-        uint256 delayBlocks;
-        uint256 futureBlocks;
-        uint256 delaySeconds;
-        uint256 futureSeconds;
+        uint64 delayBlocks;
+        uint64 futureBlocks;
+        uint64 delaySeconds;
+        uint64 futureSeconds;
     }
 
     struct TimeBounds {
@@ -80,10 +80,10 @@ interface ISequencerInbox is IDelayedMessageProvider {
         external
         view
         returns (
-            uint256,
-            uint256,
-            uint256,
-            uint256
+            uint64,
+            uint64,
+            uint64,
+            uint64
         );
 
     function dasKeySetInfo(bytes32) external view returns (bool, uint64);

--- a/test/storage/SequencerInbox.dot
+++ b/test/storage/SequencerInbox.dot
@@ -4,9 +4,9 @@ rankdir=LR
 color=black
 arrowhead=open
 node [shape=record, style=filled, fillcolor=gray95 fontname="Courier New"]
-3 [label="SequencerInbox \<\<Contract\>\>\n | {{ slot| 0 | 1 | 2 | 3 | 4-7 | 8 | 9 } | { type: \<inherited contract\>.variable (bytes) | {  uint256: totalDelayedMessagesRead (32) } | {  unallocated (12)  |  IBridge: bridge (20) } | {  unallocated (12)  |  IOwnable: rollup (20) } | {  mapping\(address=\>bool\): isBatchPoster (32) } | { <9> ISequencerInbox.MaxTimeVariation: maxTimeVariation (128) } | { <12> mapping\(bytes32=\>DasKeySetInfo\): dasKeySetInfo (32) } | {  mapping\(address=\>bool\): isSequencer (32) }}}"]
+3 [label="SequencerInbox \<\<Contract\>\>\n | {{ slot| 0 | 1 | 2 | 3 | 4 | 5 | 6 } | { type: \<inherited contract\>.variable (bytes) | {  uint256: totalDelayedMessagesRead (32) } | {  unallocated (12)  |  IBridge: bridge (20) } | {  unallocated (12)  |  IOwnable: rollup (20) } | {  mapping\(address=\>bool\): isBatchPoster (32) } | { <9> ISequencerInbox.MaxTimeVariation: maxTimeVariation (32) } | { <12> mapping\(bytes32=\>DasKeySetInfo\): dasKeySetInfo (32) } | {  mapping\(address=\>bool\): isSequencer (32) }}}"]
 
-1 [label="ISequencerInbox.MaxTimeVariation \<\<Struct\>\>\n | {{ slot| 4 | 5 | 6 | 7 } | { type: variable (bytes) | {  uint256: MaxTimeVariation.delayBlocks (32) } | {  uint256: MaxTimeVariation.futureBlocks (32) } | {  uint256: MaxTimeVariation.delaySeconds (32) } | {  uint256: MaxTimeVariation.futureSeconds (32) }}}"]
+1 [label="ISequencerInbox.MaxTimeVariation \<\<Struct\>\>\n | {{ slot| 4 } | { type: variable (bytes) | {  uint64: MaxTimeVariation.futureSeconds (8)  |  uint64: MaxTimeVariation.delaySeconds (8)  |  uint64: MaxTimeVariation.futureBlocks (8)  |  uint64: MaxTimeVariation.delayBlocks (8) }}}"]
 
 2 [label="DasKeySetInfo \<\<Struct\>\>\n | {{ slot| 0 } | { type: variable (bytes) | {  unallocated (23)  |  uint64: creationBlock (8)  |  bool: isValidKeyset (1) }}}"]
 


### PR DESCRIPTION
This PR simply packs the MaxTimeVariation members into a single slot.

Each time the sequencer posts a batch, the time boundary is calculated accessing each member of MaxTimeVariation.

Timestamps fit in uint32 data types, this is sufficient for atleast 80 years. I see uint64 is the time data type convention used in the repo so this is suitable for the MaxTimeVariation.delaySeconds/futureSeconds.

Regarding blocktime, even if Arbitrum settled on BSC (~3 second block time) or Solana (400 millisecond block time), uint64 is more than sufficient for million millions of years.

This PR saves approximately 6300 gas per sequencer batch posted --- about 2 billion gas, or 20 - 60 eth since Nitro launched.