### PR TITLE
Track L1 gas separately from basefee in batch posting report

### DIFF
--- a/src/bridge/SequencerInbox.sol
+++ b/src/bridge/SequencerInbox.sol
@@ -392,18 +392,28 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
             // this msg isn't included in the current sequencer batch, but instead added to
             // the delayed messages queue that is yet to be included
             address batchPoster = msg.sender;
-            bytes memory spendingReportMsg = abi.encodePacked(
-                block.timestamp,
-                batchPoster,
-                dataHash,
-                seqMessageIndex,
-                block.basefee
-            );
+            bytes memory spendingReportMsg;
             if (hostChainIsArbitrum) {
                 // Include extra gas for the host chain's L1 gas charging
                 uint256 l1Fees = ArbGasInfo(address(0x6c)).getCurrentTxL1GasFees();
-                uint64 extraGas = uint64(l1Fees / block.basefee);
-                spendingReportMsg = abi.encodePacked(spendingReportMsg, extraGas);
+                uint256 extraGas = l1Fees / block.basefee;
+                require(extraGas <= type(uint64).max, "L1_GAS_NOT_UINT64");
+                spendingReportMsg = abi.encodePacked(
+                    block.timestamp,
+                    batchPoster,
+                    dataHash,
+                    seqMessageIndex,
+                    block.basefee,
+                    uint64(extraGas)
+                );
+            } else {
+                spendingReportMsg = abi.encodePacked(
+                    block.timestamp,
+                    batchPoster,
+                    dataHash,
+                    seqMessageIndex,
+                    block.basefee
+                );
             }
             uint256 msgNum = bridge.submitBatchSpendingReport(
                 batchPoster,


### PR DESCRIPTION
This is more accurate as it doesn't charge the fixed costs against the L1 basefee.