### PR TITLE
Add additional redeem checks to mock Simple.sol

### DIFF
--- a/src/mocks/Simple.sol
+++ b/src/mocks/Simple.sol
@@ -30,6 +30,8 @@ contract Simple {
     }
 
     function incrementRedeem() external {
+        require(msg.sender == tx.origin, "SENDER_NOT_ORIGIN");
+        require(ArbSys(address(0x64)).wasMyCallersAddressAliased(), "NOT_ALIASED");
         counter++;
         emit RedeemedEvent(msg.sender, ArbRetryableTx(address(110)).getCurrentRedeemer());
     }


### PR DESCRIPTION
These checks catch a bug in retryable gas estimation but should always pass.