### PR TITLE
chore: release config

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,15 @@
     "url": "git+https://github.com/offchainlabs/nitro-contracts.git"
   },
   "files": [
-    "src/"
+    "src/",
+    "build/contracts/src",
+    "build/contracts/@openzeppelin"
   ],
   "bugs": {
     "url": "https://github.com/offchainlabs/nitro-contracts/issues"
   },
   "scripts": {
+    "prepublishOnly": "hardhat clean && hardhat compile",
     "build": "hardhat compile",
     "lint:test": "eslint ./test",
     "solhint": "solhint -f table src/**/*.sol",


### PR DESCRIPTION
This PR include the build artifacts to the npm release, and add a prepublish action to make sure the latest code is built before release.