### PR TITLE
Add MessageDeliveredV2 event

### DIFF
--- a/src/bridge/AbsBridge.sol
+++ b/src/bridge/AbsBridge.sol
@@ -197,6 +197,7 @@ abstract contract AbsBridge is Initializable, DelegateCallAware, IBridge {
             baseFeeL1,
             blockTimestamp
         );
+        emit MessageDeliveredV2(kind, sender);
         return count;
     }
 

--- a/src/bridge/IBridge.sol
+++ b/src/bridge/IBridge.sol
@@ -19,6 +19,8 @@ interface IBridge {
         uint64 timestamp
     );
 
+    event MessageDeliveredV2(uint8 indexed kind, address indexed sender);
+
     event BridgeCallTriggered(
         address indexed outbox,
         address indexed to,


### PR DESCRIPTION
This event allows bridges to efficiently query the deposit history for an address without requiring an external indexer.