### PR TITLE
Add ERC20Bridge balance check

### DIFF
--- a/src/bridge/ERC20Bridge.sol
+++ b/src/bridge/ERC20Bridge.sol
@@ -15,6 +15,11 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
  * @title Staging ground for incoming and outgoing messages
  * @notice Unlike the standard Eth bridge, native token bridge escrows the custom ERC20 token which is
  * used as native currency on L2.
+ * @dev Fees are paid in this token. There are certain restrictions on the native token:
+ *       - The token can't be rebasing or have a transfer fee
+ *       - The token must only be transferrable via a call to the token address itself
+ *       - The token must only be able to set allowance via a call to the token address itself
+ *       - The token must not have a callback on transfer, and more generally a user must not be able to make a transfer to themselves revert
  */
 contract ERC20Bridge is AbsBridge, IERC20Bridge {
     using SafeERC20 for IERC20;

--- a/src/bridge/ERC20Bridge.sol
+++ b/src/bridge/ERC20Bridge.sol
@@ -68,7 +68,7 @@ contract ERC20Bridge is AbsBridge, IERC20Bridge {
         success = true;
 
         // if there's data do additional contract call. Make sure that call is not used to
-        // change bridge contract's balance of the native token
+        // decrease bridge contract's balance of the native token
         if (data.length > 0) {
             uint256 bridgeBalanceBefore = IERC20(_nativeToken).balanceOf(address(this));
 
@@ -76,7 +76,7 @@ contract ERC20Bridge is AbsBridge, IERC20Bridge {
             (success, returnData) = to.call(data);
 
             uint256 bridgeBalanceAfter = IERC20(_nativeToken).balanceOf(address(this));
-            if (bridgeBalanceAfter != bridgeBalanceBefore) {
+            if (bridgeBalanceAfter < bridgeBalanceBefore) {
                 revert CallNotAllowed();
             }
         }

--- a/src/bridge/ERC20Bridge.sol
+++ b/src/bridge/ERC20Bridge.sol
@@ -7,7 +7,7 @@ pragma solidity ^0.8.4;
 import "./AbsBridge.sol";
 import "./IERC20Bridge.sol";
 import "../libraries/AddressAliasHelper.sol";
-import {InvalidTokenSet, CallTargetNotAllowed} from "../libraries/Error.sol";
+import {InvalidTokenSet, CallTargetNotAllowed, CallNotAllowed} from "../libraries/Error.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
@@ -50,20 +50,30 @@ contract ERC20Bridge is AbsBridge, IERC20Bridge {
         uint256 value,
         bytes memory data
     ) internal override returns (bool success, bytes memory returnData) {
+        address _nativeToken = nativeToken;
+
         // we don't allow outgoing calls to native token contract because it could
         // result in loss of native tokens which are escrowed by ERC20Bridge
-        if (to == nativeToken) {
-            revert CallTargetNotAllowed(nativeToken);
+        if (to == _nativeToken) {
+            revert CallTargetNotAllowed(_nativeToken);
         }
 
         // first release native token
-        IERC20(nativeToken).safeTransfer(to, value);
+        IERC20(_nativeToken).safeTransfer(to, value);
         success = true;
 
-        // if there's data do additional contract call
+        // if there's data do additional contract call. Make sure that call is not used to
+        // change bridge contract's balance of the native token
         if (data.length > 0) {
+            uint256 bridgeBalanceBefore = IERC20(_nativeToken).balanceOf(address(this));
+
             // solhint-disable-next-line avoid-low-level-calls
             (success, returnData) = to.call(data);
+
+            uint256 bridgeBalanceAfter = IERC20(_nativeToken).balanceOf(address(this));
+            if (bridgeBalanceAfter != bridgeBalanceBefore) {
+                revert CallNotAllowed();
+            }
         }
     }
 

--- a/src/bridge/IERC20Bridge.sol
+++ b/src/bridge/IERC20Bridge.sol
@@ -11,9 +11,11 @@ import "./IBridge.sol";
 interface IERC20Bridge is IBridge {
     /**
      * @dev token that is escrowed in bridge on L1 side and minted on L2 as native currency.
-     * Also fees are paid in this token. ERC777, fee on transfer tokens and rebasing tokens
-     * are not supported to be used as chain's native token, as they can break collateralization
-     * invariants.
+     * Fees are paid in this token. There are certain restrictions on the native token:
+     *  - The token can't be rebasing or have a transfer fee
+     *  - The token must only be transferrable via a call to the token address itself
+     *  - The token must only be able to set allowance via a call to the token address itself
+     *  - The token must not have a callback on transfer, and more generally a user must not be able to make a transfer to themselves revert
      */
     function nativeToken() external view returns (address);
 

--- a/src/libraries/Error.sol
+++ b/src/libraries/Error.sol
@@ -69,6 +69,9 @@ error InvalidTokenSet(address token);
 /// @param target address of the call receiver
 error CallTargetNotAllowed(address target);
 
+/// @dev Call that changes the balance of ERC20Bridge is not allowed
+error CallNotAllowed();
+
 // Inbox Errors
 
 /// @dev The contract is paused, so cannot be paused

--- a/test/foundry/ERC20Bridge.t.sol
+++ b/test/foundry/ERC20Bridge.t.sol
@@ -340,4 +340,50 @@ contract ERC20BridgeTest is AbsBridgeTest {
         vm.prank(outbox);
         bridge.executeCall({to: to, value: 10, data: "some data"});
     }
+
+    function test_executeCall_revert_CallNotAllowed() public {
+        // deploy and initi bridge contracts
+        address _rollup = makeAddr("rollup");
+        address _outbox = makeAddr("outbox");
+        address _gateway = address(new MockGateway());
+        address _nativeToken = address(new MockBridgedToken(_gateway));
+        IERC20Bridge _bridge = IERC20Bridge(TestUtil.deployProxy(address(new ERC20Bridge())));
+        _bridge.initialize(IOwnable(_rollup), address(_nativeToken));
+
+        // allow outbox
+        vm.prank(_rollup);
+        _bridge.setOutbox(_outbox, true);
+
+        // fund bridge
+        MockBridgedToken(_nativeToken).transfer(address(_bridge), 100 ether);
+
+        // executeCall shall revert when call changes balance of the bridge
+        address to = _gateway;
+        uint256 withdrawAmount = 25 ether;
+        bytes memory data = abi.encodeWithSelector(
+            MockGateway.withdraw.selector, MockBridgedToken(_nativeToken), withdrawAmount
+        );
+        vm.expectRevert(abi.encodeWithSelector(CallNotAllowed.selector));
+        vm.prank(_outbox);
+        _bridge.executeCall({to: to, value: 10, data: data});
+    }
+}
+
+contract MockBridgedToken is ERC20 {
+    address public gateway;
+
+    constructor(address _gateway) ERC20("MockBridgedToken", "TT") {
+        gateway = _gateway;
+        _mint(msg.sender, 1_000_000 ether);
+    }
+    function bridgeBurn(address account, uint256 amount) external {
+        require(msg.sender == gateway, "ONLY_GATEWAY");
+        _burn(account, amount);
+    }
+}
+
+contract MockGateway {
+    function withdraw(MockBridgedToken token, uint256 amount) external {
+        token.bridgeBurn(msg.sender, amount);
+    }
 }


### PR DESCRIPTION
When withdraw-and-call is used in ERC20 based chains, it is important to make sure that extra call cannot be used to move escrowed native token in any way. We enforce it by doing native token balance check for bridge before/after the extra call is executed.