### PR TITLE
Update salt used for creating new rollups 

### DIFF
--- a/scripts/rollupCreation.ts
+++ b/scripts/rollupCreation.ts
@@ -78,14 +78,17 @@ export async function createRollup(feeToken?: string) {
 
     // Call the createRollup function
     console.log('Calling createRollup to generate a new rollup ...')
+    const deployParams = {
+      config: config.rollupConfig,
+      batchPoster: config.batchPoster,
+      validators: config.validators,
+      maxDataSize: maxDataSize,
+      nativeToken: feeToken,
+      deployFactoriesToL2: true,
+      maxFeePerGasForRetryables: MAX_FER_PER_GAS
+    }
     const createRollupTx = await rollupCreator.createRollup(
-      config.rollupConfig,
-      config.batchPoster,
-      config.validators,
-      maxDataSize,
-      feeToken,
-      true,
-      MAX_FER_PER_GAS,
+      deployParams,
       {
         value: feeCost,
       }

--- a/src/rollup/RollupCreator.sol
+++ b/src/rollup/RollupCreator.sol
@@ -109,27 +109,22 @@ contract RollupCreator is Ownable {
         payable
         returns (address)
     {
-        {
-            // Make sure the immutable maxDataSize is as expected
-            (, ISequencerInbox ethSequencerInbox, IInboxBase ethInbox, , ) = bridgeCreator
-                .ethBasedTemplates();
-            require(
-                deployParams.maxDataSize == ethSequencerInbox.maxDataSize(),
-                "SI_MAX_DATA_SIZE_MISMATCH"
-            );
-            require(deployParams.maxDataSize == ethInbox.maxDataSize(), "I_MAX_DATA_SIZE_MISMATCH");
+        // Make sure the immutable maxDataSize is as expected
+        (, ISequencerInbox ethSequencerInbox, IInboxBase ethInbox, , ) = bridgeCreator
+            .ethBasedTemplates();
+        require(
+            deployParams.maxDataSize == ethSequencerInbox.maxDataSize(),
+            "SI_MAX_DATA_SIZE_MISMATCH"
+        );
+        require(deployParams.maxDataSize == ethInbox.maxDataSize(), "I_MAX_DATA_SIZE_MISMATCH");
 
-            (, ISequencerInbox erc20SequencerInbox, IInboxBase erc20Inbox, , ) = bridgeCreator
-                .erc20BasedTemplates();
-            require(
-                deployParams.maxDataSize == erc20SequencerInbox.maxDataSize(),
-                "SI_MAX_DATA_SIZE_MISMATCH"
-            );
-            require(
-                deployParams.maxDataSize == erc20Inbox.maxDataSize(),
-                "I_MAX_DATA_SIZE_MISMATCH"
-            );
-        }
+        (, ISequencerInbox erc20SequencerInbox, IInboxBase erc20Inbox, , ) = bridgeCreator
+            .erc20BasedTemplates();
+        require(
+            deployParams.maxDataSize == erc20SequencerInbox.maxDataSize(),
+            "SI_MAX_DATA_SIZE_MISMATCH"
+        );
+        require(deployParams.maxDataSize == erc20Inbox.maxDataSize(), "I_MAX_DATA_SIZE_MISMATCH");
 
         // create proxy admin which will manage bridge contracts
         ProxyAdmin proxyAdmin = new ProxyAdmin();

--- a/src/rollup/RollupCreator.sol
+++ b/src/rollup/RollupCreator.sol
@@ -97,10 +97,10 @@ contract RollupCreator is Ownable {
      *          - validators    The list of validator addresses, not used when set to empty list
      *          - nativeToken   Address of the custom fee token used by rollup. If rollup is ETH-based address(0) should be provided
      *          - deployFactoriesToL2 Whether to deploy L2 factories using retryable tickets. If true, retryables need to be paid for in native currency.
-     *                        Deploying factories via retryable tickets at rollup creation time is the most reliable method to do it since it
-     *                        doesn't require paying the L1 gas. If deployment is not done as part of rollup creation TX, there is a risk that
-     *                        anyone can try to deploy factories and potentially burn the nonce 0 (ie. due to gas price spike when doing direct
-     *                        L2 TX). That would mean we permanently lost capability to deploy deterministic factory at expected address.
+     *                          Deploying factories via retryable tickets at rollup creation time is the most reliable method to do it since it
+     *                          doesn't require paying the L1 gas. If deployment is not done as part of rollup creation TX, there is a risk that
+     *                          anyone can try to deploy factories and potentially burn the nonce 0 (ie. due to gas price spike when doing direct
+     *                          L2 TX). That would mean we permanently lost capability to deploy deterministic factory at expected address.
      *          - maxFeePerGasForRetryables price bid for L2 execution.
      * @return The address of the newly created rollup
      */

--- a/test/contract/arbRollup.spec.ts
+++ b/test/contract/arbRollup.spec.ts
@@ -271,17 +271,20 @@ const setup = async () => {
   const deployParams = {
     config: await getDefaultConfig(),
     batchPoster: await sequencer.getAddress(),
-    validators: [await val1.getAddress(), await val2.getAddress(), await val3.getAddress()],
+    validators: [
+      await val1.getAddress(),
+      await val2.getAddress(),
+      await val3.getAddress(),
+    ],
     maxDataSize: 117964,
     nativeToken: ethers.constants.AddressZero,
     deployFactoriesToL2: true,
     maxFeePerGasForRetryables: maxFeePerGas,
   }
 
-  const response = await rollupCreator.createRollup(
-    deployParams,
-    { value: ethers.utils.parseEther('0.2') }
-  )
+  const response = await rollupCreator.createRollup(deployParams, {
+    value: ethers.utils.parseEther('0.2'),
+  })
 
   const rec = await response.wait()
 

--- a/test/contract/arbRollup.spec.ts
+++ b/test/contract/arbRollup.spec.ts
@@ -267,14 +267,19 @@ const setup = async () => {
   )
 
   const maxFeePerGas = BigNumber.from('1000000000')
+
+  const deployParams = {
+    config: await getDefaultConfig(),
+    batchPoster: await sequencer.getAddress(),
+    validators: [await val1.getAddress(), await val2.getAddress(), await val3.getAddress()],
+    maxDataSize: 117964,
+    nativeToken: ethers.constants.AddressZero,
+    deployFactoriesToL2: true,
+    maxFeePerGasForRetryables: maxFeePerGas,
+  }
+
   const response = await rollupCreator.createRollup(
-    await getDefaultConfig(),
-    await sequencer.getAddress(),
-    [await val1.getAddress(), await val2.getAddress(), await val3.getAddress()],
-    117964,
-    ethers.constants.AddressZero,
-    true,
-    maxFeePerGas,
+    deployParams,
     { value: ethers.utils.parseEther('0.2') }
   )
 

--- a/test/foundry/RollupCreator.t.sol
+++ b/test/foundry/RollupCreator.t.sol
@@ -32,23 +32,20 @@ contract RollupCreatorTest is Test {
     uint256 public constant MAX_FEE_PER_GAS = 1_000_000_000;
     uint256 public constant MAX_DATA_SIZE = 117_964;
 
-    BridgeCreator.BridgeContracts public ethBasedTemplates =
-        BridgeCreator.BridgeContracts({
-            bridge: new Bridge(),
-            sequencerInbox: new SequencerInbox(MAX_DATA_SIZE),
-            inbox: new Inbox(MAX_DATA_SIZE),
-            rollupEventInbox: new RollupEventInbox(),
-            outbox: new Outbox()
-        });
-    BridgeCreator.BridgeContracts public erc20BasedTemplates =
-        BridgeCreator.BridgeContracts({
-            bridge: new ERC20Bridge(),
-            sequencerInbox: ethBasedTemplates.sequencerInbox,
-            inbox: new ERC20Inbox(MAX_DATA_SIZE),
-            rollupEventInbox: new ERC20RollupEventInbox(),
-            outbox: new ERC20Outbox()
-        });
-
+    BridgeCreator.BridgeContracts public ethBasedTemplates = BridgeCreator.BridgeContracts({
+        bridge: new Bridge(),
+        sequencerInbox: new SequencerInbox(MAX_DATA_SIZE),
+        inbox: new Inbox(MAX_DATA_SIZE),
+        rollupEventInbox: new RollupEventInbox(),
+        outbox: new Outbox()
+    });
+    BridgeCreator.BridgeContracts public erc20BasedTemplates = BridgeCreator.BridgeContracts({
+        bridge: new ERC20Bridge(),
+        sequencerInbox: ethBasedTemplates.sequencerInbox,
+        inbox: new ERC20Inbox(MAX_DATA_SIZE),
+        rollupEventInbox: new ERC20RollupEventInbox(),
+        outbox: new ERC20Outbox()
+    });
 
     /* solhint-disable func-name-mixedcase */
     function setUp() public {
@@ -92,12 +89,8 @@ contract RollupCreatorTest is Test {
         vm.startPrank(deployer);
 
         // deployment params
-        ISequencerInbox.MaxTimeVariation memory timeVars = ISequencerInbox.MaxTimeVariation(
-            ((60 * 60 * 24) / 15),
-            12,
-            60 * 60 * 24,
-            60 * 60
-        );
+        ISequencerInbox.MaxTimeVariation memory timeVars =
+            ISequencerInbox.MaxTimeVariation(((60 * 60 * 24) / 15), 12, 60 * 60 * 24, 60 * 60);
         Config memory config = Config({
             confirmPeriodBlocks: 20,
             extraChallengeTimeBlocks: 200,
@@ -123,9 +116,18 @@ contract RollupCreatorTest is Test {
         validators[0] = makeAddr("validator1");
         validators[1] = makeAddr("validator2");
 
-        address rollupAddress = rollupCreator.createRollup{value: factoryDeploymentFunds}(
-            config, batchPoster, validators, MAX_DATA_SIZE, address(0), true, MAX_FEE_PER_GAS
-        );
+        RollupCreator.RollupDeploymentParams memory deployParams = RollupCreator
+            .RollupDeploymentParams({
+            config: config,
+            batchPoster: batchPoster,
+            validators: validators,
+            maxDataSize: MAX_DATA_SIZE,
+            nativeToken: address(0),
+            deployFactoriesToL2: true,
+            maxFeePerGasForRetryables: MAX_FEE_PER_GAS
+        });
+        address rollupAddress =
+            rollupCreator.createRollup{value: factoryDeploymentFunds}(deployParams);
 
         vm.stopPrank();
 
@@ -197,9 +199,7 @@ contract RollupCreatorTest is Test {
 
         // upgrade executor owns rollup
         assertEq(
-            IOwnable(rollupAddress).owner(),
-            upgradeExecutorExpectedAddress,
-            "Invalid rollup owner"
+            IOwnable(rollupAddress).owner(), upgradeExecutorExpectedAddress, "Invalid rollup owner"
         );
         assertEq(
             _getProxyAdmin(rollupAddress),
@@ -208,36 +208,26 @@ contract RollupCreatorTest is Test {
         );
 
         // check rollupOwner has executor role
-        AccessControlUpgradeable executor = AccessControlUpgradeable(
-            upgradeExecutorExpectedAddress
-        );
+        AccessControlUpgradeable executor = AccessControlUpgradeable(upgradeExecutorExpectedAddress);
         assertTrue(
-            executor.hasRole(keccak256("EXECUTOR_ROLE"), rollupOwner),
-            "Invalid executor role"
+            executor.hasRole(keccak256("EXECUTOR_ROLE"), rollupOwner), "Invalid executor role"
         );
 
         // check funds are refunded
         uint256 balanceAfter = deployer.balance;
-        uint256 factoryDeploymentCost = deployHelper.getDeploymentTotalCost(
-            rollup.inbox(),
-            MAX_FEE_PER_GAS
-        );
+        uint256 factoryDeploymentCost =
+            deployHelper.getDeploymentTotalCost(rollup.inbox(), MAX_FEE_PER_GAS);
         assertEq(balanceBefore - balanceAfter, factoryDeploymentCost, "Invalid balance");
     }
 
     function test_createErc20Rollup() public {
         vm.startPrank(deployer);
-        address nativeToken = address(
-            new ERC20PresetFixedSupply("Appchain Token", "App", 1_000_000 ether, deployer)
-        );
+        address nativeToken =
+            address(new ERC20PresetFixedSupply("Appchain Token", "App", 1_000_000 ether, deployer));
 
         // deployment params
-        ISequencerInbox.MaxTimeVariation memory timeVars = ISequencerInbox.MaxTimeVariation(
-            ((60 * 60 * 24) / 15),
-            12,
-            60 * 60 * 24,
-            60 * 60
-        );
+        ISequencerInbox.MaxTimeVariation memory timeVars =
+            ISequencerInbox.MaxTimeVariation(((60 * 60 * 24) / 15), 12, 60 * 60 * 24, 60 * 60);
         Config memory config = Config({
             confirmPeriodBlocks: 20,
             extraChallengeTimeBlocks: 200,
@@ -253,9 +243,7 @@ contract RollupCreatorTest is Test {
         });
 
         // approve fee token to pay for deployment of L2 factories
-        uint256 expectedCost = 0.1247 ether +
-            4 *
-            (1400 * 100_000_000_000 + 100_000 * 1_000_000_000);
+        uint256 expectedCost = 0.1247 ether + 4 * (1400 * 100_000_000_000 + 100_000 * 1_000_000_000);
         IERC20(nativeToken).approve(address(rollupCreator), expectedCost);
 
         /// deploy rollup
@@ -263,9 +251,19 @@ contract RollupCreatorTest is Test {
         address[] memory validators = new address[](2);
         validators[0] = makeAddr("validator1");
         validators[1] = makeAddr("validator2");
-        address rollupAddress = rollupCreator.createRollup(
-            config, batchPoster, validators, MAX_DATA_SIZE, nativeToken, true, MAX_FEE_PER_GAS
-        );
+
+        RollupCreator.RollupDeploymentParams memory deployParams = RollupCreator
+            .RollupDeploymentParams({
+            config: config,
+            batchPoster: batchPoster,
+            validators: validators,
+            maxDataSize: MAX_DATA_SIZE,
+            nativeToken: nativeToken,
+            deployFactoriesToL2: true,
+            maxFeePerGasForRetryables: MAX_FEE_PER_GAS
+        });
+
+        address rollupAddress = rollupCreator.createRollup(deployParams);
 
         vm.stopPrank();
 
@@ -295,9 +293,7 @@ contract RollupCreatorTest is Test {
         // native token check
         IBridge bridge = RollupCore(address(rollupAddress)).bridge();
         assertEq(
-            IERC20Bridge(address(bridge)).nativeToken(),
-            nativeToken,
-            "Invalid native token ref"
+            IERC20Bridge(address(bridge)).nativeToken(), nativeToken, "Invalid native token ref"
         );
 
         // check proxy admin for non-rollup contracts
@@ -344,9 +340,7 @@ contract RollupCreatorTest is Test {
 
         // upgrade executor owns rollup
         assertEq(
-            IOwnable(rollupAddress).owner(),
-            upgradeExecutorExpectedAddress,
-            "Invalid rollup owner"
+            IOwnable(rollupAddress).owner(), upgradeExecutorExpectedAddress, "Invalid rollup owner"
         );
         assertEq(
             _getProxyAdmin(rollupAddress),
@@ -355,12 +349,9 @@ contract RollupCreatorTest is Test {
         );
 
         // check rollupOwner has executor role
-        AccessControlUpgradeable executor = AccessControlUpgradeable(
-            upgradeExecutorExpectedAddress
-        );
+        AccessControlUpgradeable executor = AccessControlUpgradeable(upgradeExecutorExpectedAddress);
         assertTrue(
-            executor.hasRole(keccak256("EXECUTOR_ROLE"), rollupOwner),
-            "Invalid executor role"
+            executor.hasRole(keccak256("EXECUTOR_ROLE"), rollupOwner), "Invalid executor role"
         );
     }
 
@@ -368,12 +359,8 @@ contract RollupCreatorTest is Test {
         vm.startPrank(deployer);
 
         // deployment params
-        ISequencerInbox.MaxTimeVariation memory timeVars = ISequencerInbox.MaxTimeVariation(
-            ((60 * 60 * 24) / 15),
-            12,
-            60 * 60 * 24,
-            60 * 60
-        );
+        ISequencerInbox.MaxTimeVariation memory timeVars =
+            ISequencerInbox.MaxTimeVariation(((60 * 60 * 24) / 15), 12, 60 * 60 * 24, 60 * 60);
         Config memory config = Config({
             confirmPeriodBlocks: 20,
             extraChallengeTimeBlocks: 200,
@@ -397,9 +384,19 @@ contract RollupCreatorTest is Test {
         address[] memory validators = new address[](2);
         validators[0] = makeAddr("validator1");
         validators[1] = makeAddr("validator2");
-        address rollupAddress = rollupCreator.createRollup{value: factoryDeploymentFunds}(
-            config, batchPoster, validators, MAX_DATA_SIZE, address(0), true, MAX_FEE_PER_GAS
-        );
+
+        RollupCreator.RollupDeploymentParams memory deployParams = RollupCreator
+            .RollupDeploymentParams({
+            config: config,
+            batchPoster: batchPoster,
+            validators: validators,
+            maxDataSize: MAX_DATA_SIZE,
+            nativeToken: address(0),
+            deployFactoriesToL2: true,
+            maxFeePerGasForRetryables: MAX_FEE_PER_GAS
+        });
+        address rollupAddress =
+            rollupCreator.createRollup{value: factoryDeploymentFunds}(deployParams);
 
         vm.stopPrank();
 
@@ -407,16 +404,12 @@ contract RollupCreatorTest is Test {
         RollupCore rollup = RollupCore(rollupAddress);
         address inbox = address(rollup.inbox());
         address proxyAdmin = computeCreateAddress(address(rollupCreator), 1);
-        IUpgradeExecutor upgradeExecutor = IUpgradeExecutor(
-            computeCreateAddress(address(rollupCreator), 4)
-        );
+        IUpgradeExecutor upgradeExecutor =
+            IUpgradeExecutor(computeCreateAddress(address(rollupCreator), 4));
 
         Dummy newLogicImpl = new Dummy();
         bytes memory data = abi.encodeWithSelector(
-            ProxyUpgradeAction.perform.selector,
-            address(proxyAdmin),
-            inbox,
-            address(newLogicImpl)
+            ProxyUpgradeAction.perform.selector, address(proxyAdmin), inbox, address(newLogicImpl)
         );
 
         address upgradeAction = address(new ProxyUpgradeAction());
@@ -468,19 +461,14 @@ contract RollupCreatorTest is Test {
     }
 
     function _getSecondary(address proxy) internal view returns (address) {
-        bytes32 secondarySlot = bytes32(
-            uint256(keccak256("eip1967.proxy.implementation.secondary")) - 1
-        );
+        bytes32 secondarySlot =
+            bytes32(uint256(keccak256("eip1967.proxy.implementation.secondary")) - 1);
         return address(uint160(uint256(vm.load(proxy, secondarySlot))));
     }
 }
 
 contract ProxyUpgradeAction {
-    function perform(
-        address admin,
-        address payable target,
-        address newLogic
-    ) public payable {
+    function perform(address admin, address payable target, address newLogic) public payable {
         ProxyAdmin(admin).upgrade(TransparentUpgradeableProxy(target), newLogic);
     }
 }


### PR DESCRIPTION
All the input parameters for 'createRollup' entrypoint should be included in rollup's salt.

To make this more convenient input parameters are packed into 'RollupDeploymentParams' struct which looks like this:

    struct RollupDeploymentParams {
        Config config;
        address batchPoster;
        address[] validators;
        uint256 maxDataSize;
        address nativeToken;
        bool deployFactoriesToL2;
        uint256 maxFeePerGasForRetryables;
    }