### PR TITLE
feat: outbox postUpgradeInit

### DIFF
--- a/src/bridge/AbsOutbox.sol
+++ b/src/bridge/AbsOutbox.sol
@@ -12,7 +12,8 @@ import {
     UnknownRoot,
     AlreadySpent,
     BridgeCallFailed,
-    HadZeroInit
+    HadZeroInit,
+    BadPostUpgradeInit
 } from "../libraries/Error.sol";
 import "./IBridge.sol";
 import "./IOutbox.sol";
@@ -74,6 +75,19 @@ abstract contract AbsOutbox is DelegateCallAware, IOutbox {
         });
         bridge = _bridge;
         rollup = address(_bridge.rollup());
+    }
+
+    function postUpgradeInit() external onlyDelegated onlyProxyOwner {
+        // prevent postUpgradeInit within a withdrawal
+        if (context.l2Block != L2BLOCK_DEFAULT_CONTEXT) revert BadPostUpgradeInit();
+        context = L2ToL1Context({
+            l2Block: L2BLOCK_DEFAULT_CONTEXT,
+            l1Block: L1BLOCK_DEFAULT_CONTEXT,
+            timestamp: TIMESTAMP_DEFAULT_CONTEXT,
+            outputId: OUTPUTID_DEFAULT_CONTEXT,
+            sender: SENDER_DEFAULT_CONTEXT,
+            withdrawalAmount: _defaultContextAmount()
+        });
     }
 
     function updateSendRoot(bytes32 root, bytes32 l2BlockHash) external {

--- a/src/bridge/IOutbox.sol
+++ b/src/bridge/IOutbox.sol
@@ -119,4 +119,10 @@ interface IOutbox {
         uint256 path,
         bytes32 item
     ) external pure returns (bytes32);
+
+    /**
+     * @dev function to be called one time during the outbox upgrade process
+     *      this is used to fix the storage slots
+     */
+    function postUpgradeInit() external;
 }

--- a/src/libraries/Error.sol
+++ b/src/libraries/Error.sol
@@ -7,8 +7,11 @@ pragma solidity ^0.8.4;
 /// @dev Init was already called
 error AlreadyInit();
 
-/// Init was called with param set to zero that must be nonzero
+/// @dev Init was called with param set to zero that must be nonzero
 error HadZeroInit();
+
+/// @dev Thrown when post upgrade init validation fails
+error BadPostUpgradeInit();
 
 /// @dev Thrown when non owner tries to access an only-owner function
 /// @param sender The msg.sender who is not the owner

--- a/src/test-helpers/OutboxWithoutOptTester.sol
+++ b/src/test-helpers/OutboxWithoutOptTester.sol
@@ -48,6 +48,8 @@ contract OutboxWithoutOptTester is DelegateCallAware, IOutbox {
         rollup = address(_bridge.rollup());
     }
 
+    function postUpgradeInit() external {}
+
     function updateSendRoot(bytes32 root, bytes32 l2BlockHash) external override {
         //if (msg.sender != rollup) revert NotRollup(msg.sender, rollup);  //test only!!!
         roots[root] = l2BlockHash;


### PR DESCRIPTION
Outbox L2ToL1Context struct is changed from
```solidity
    struct L2ToL1Context {
        uint128 l2Block; // slot 1
        uint128 l1Block; 
        uint128 timestamp; // slot 2
        bytes32 outputId; // slot 3
        address sender; // slot 4
    } 
```
to
```solidity
    struct L2ToL1Context {
        uint128 l2Block; // slot 1
        uint128 timestamp;
        bytes32 outputId; // slot 2
        address sender; // slot 3
        uint96 l1Block;
        uint256 withdrawalAmount; // slot 4
    }
```
This PR add `postUpgradeInit` to Outbox which is supposed to be called with upgradeAndCall to fix the default context.
