### PR TITLE
feat: allow rollup update

### DIFF
--- a/src/bridge/AbsBridge.sol
+++ b/src/bridge/AbsBridge.sol
@@ -70,6 +70,7 @@ abstract contract AbsBridge is Initializable, DelegateCallAware, IBridge {
     /// @notice Allows the rollup owner to set another rollup address
     function updateRollupAddress(IOwnable _rollup) external onlyRollupOrOwner {
         rollup = _rollup;
+        emit RollupUpdated(address(_rollup));
     }
 
     /// @dev returns the address of current active Outbox, or zero if no outbox is active

--- a/src/bridge/AbsBridge.sol
+++ b/src/bridge/AbsBridge.sol
@@ -14,6 +14,7 @@ import {
     NotSequencerInbox,
     NotOutbox,
     InvalidOutboxSet,
+    InvalidRollupSet,
     BadSequencerMessageNumber
 } from "../libraries/Error.sol";
 import "./IBridge.sol";
@@ -57,11 +58,6 @@ abstract contract AbsBridge is Initializable, DelegateCallAware, IBridge {
 
     address internal constant EMPTY_ACTIVEOUTBOX = address(type(uint160).max);
 
-    /// @notice Allows the proxy owner to set the rollup address
-    function updateRollupAddress(IOwnable _rollup) external onlyDelegated onlyProxyOwner {
-        rollup = _rollup;
-    }
-
     modifier onlyRollupOrOwner() {
         if (msg.sender != address(rollup)) {
             address rollupOwner = rollup.owner();
@@ -70,6 +66,11 @@ abstract contract AbsBridge is Initializable, DelegateCallAware, IBridge {
             }
         }
         _;
+    }
+
+    /// @notice Allows the rollup owner to set another rollup address
+    function updateRollupAddress(IOwnable _rollup) external onlyRollupOrOwner {
+        rollup = _rollup;
     }
 
     /// @dev returns the address of current active Outbox, or zero if no outbox is active

--- a/src/bridge/AbsBridge.sol
+++ b/src/bridge/AbsBridge.sol
@@ -57,6 +57,11 @@ abstract contract AbsBridge is Initializable, DelegateCallAware, IBridge {
 
     address internal constant EMPTY_ACTIVEOUTBOX = address(type(uint160).max);
 
+    /// @notice Allows the proxy owner to set the rollup address
+    function updateRollupAddress(IOwnable _rollup) external onlyDelegated onlyProxyOwner {
+        rollup = _rollup;
+    }
+
     modifier onlyRollupOrOwner() {
         if (msg.sender != address(rollup)) {
             address rollupOwner = rollup.owner();

--- a/src/bridge/AbsBridge.sol
+++ b/src/bridge/AbsBridge.sol
@@ -14,7 +14,6 @@ import {
     NotSequencerInbox,
     NotOutbox,
     InvalidOutboxSet,
-    InvalidRollupSet,
     BadSequencerMessageNumber
 } from "../libraries/Error.sol";
 import "./IBridge.sol";

--- a/src/bridge/AbsOutbox.sol
+++ b/src/bridge/AbsOutbox.sol
@@ -76,8 +76,10 @@ abstract contract AbsOutbox is DelegateCallAware, IOutbox {
         rollup = address(_bridge.rollup());
     }
 
-    /// @notice Allows the proxy owner to set the rollup address
-    function updateRollupAddress() external onlyDelegated onlyProxyOwner {
+    /// @notice Allows the rollup owner to sync the rollup address
+    function updateRollupAddress() external {
+        if (msg.sender != IOwnable(rollup).owner())
+            revert NotOwner(msg.sender, IOwnable(rollup).owner());
         rollup = address(bridge.rollup());
     }
 

--- a/src/bridge/AbsOutbox.sol
+++ b/src/bridge/AbsOutbox.sol
@@ -13,7 +13,8 @@ import {
     AlreadySpent,
     BridgeCallFailed,
     HadZeroInit,
-    BadPostUpgradeInit
+    BadPostUpgradeInit,
+    RollupNotChanged
 } from "../libraries/Error.sol";
 import "./IBridge.sol";
 import "./IOutbox.sol";
@@ -94,7 +95,9 @@ abstract contract AbsOutbox is DelegateCallAware, IOutbox {
     function updateRollupAddress() external {
         if (msg.sender != IOwnable(rollup).owner())
             revert NotOwner(msg.sender, IOwnable(rollup).owner());
-        rollup = address(bridge.rollup());
+        address newRollup = address(bridge.rollup());
+        if (rollup == newRollup) revert RollupNotChanged();
+        rollup = newRollup;
     }
 
     function updateSendRoot(bytes32 root, bytes32 l2BlockHash) external {

--- a/src/bridge/AbsOutbox.sol
+++ b/src/bridge/AbsOutbox.sol
@@ -76,6 +76,11 @@ abstract contract AbsOutbox is DelegateCallAware, IOutbox {
         rollup = address(_bridge.rollup());
     }
 
+    /// @notice Allows the proxy owner to set the rollup address
+    function updateRollupAddress() external onlyDelegated onlyProxyOwner {
+        rollup = address(bridge.rollup());
+    }
+
     function updateSendRoot(bytes32 root, bytes32 l2BlockHash) external {
         if (msg.sender != rollup) revert NotRollup(msg.sender, rollup);
         roots[root] = l2BlockHash;

--- a/src/bridge/IBridge.sol
+++ b/src/bridge/IBridge.sol
@@ -97,4 +97,6 @@ interface IBridge {
     function setDelayedInbox(address inbox, bool enabled) external;
 
     function setOutbox(address inbox, bool enabled) external;
+
+    function updateRollupAddress(IOwnable _rollup) external;
 }

--- a/src/bridge/IBridge.sol
+++ b/src/bridge/IBridge.sol
@@ -32,6 +32,8 @@ interface IBridge {
 
     event SequencerInboxUpdated(address newSequencerInbox);
 
+    event RollupUpdated(address rollup);
+
     function allowedDelayedInboxList(uint256) external returns (address);
 
     function allowedOutboxList(uint256) external returns (address);

--- a/src/bridge/IOutbox.sol
+++ b/src/bridge/IOutbox.sol
@@ -31,6 +31,8 @@ interface IOutbox {
 
     function updateSendRoot(bytes32 sendRoot, bytes32 l2BlockHash) external;
 
+    function updateRollupAddress() external;
+
     /// @notice When l2ToL1Sender returns a nonzero address, the message was originated by an L2 account
     ///         When the return value is zero, that means this is a system message
     /// @dev the l2ToL1Sender behaves as the tx.origin, the msg.sender should be validated to protect against reentrancies

--- a/src/bridge/ISequencerInbox.sol
+++ b/src/bridge/ISequencerInbox.sol
@@ -177,4 +177,6 @@ interface ISequencerInbox is IDelayedMessageProvider {
     // ---------- initializer ----------
 
     function initialize(IBridge bridge_, MaxTimeVariation calldata maxTimeVariation_) external;
+
+    function updateRollupAddress() external;
 }

--- a/src/bridge/SequencerInbox.sol
+++ b/src/bridge/SequencerInbox.sol
@@ -91,8 +91,10 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         maxTimeVariation = maxTimeVariation_;
     }
 
-    /// @notice Allows the proxy owner to set the rollup address
-    function updateRollupAddress() external onlyDelegated onlyProxyOwner {
+    /// @notice Allows the rollup owner to sync the rollup address
+    function updateRollupAddress() external {
+        if (msg.sender != IOwnable(rollup).owner())
+            revert NotOwner(msg.sender, IOwnable(rollup).owner());
         rollup = bridge.rollup();
     }
 

--- a/src/bridge/SequencerInbox.sol
+++ b/src/bridge/SequencerInbox.sol
@@ -20,7 +20,8 @@ import {
     DataNotAuthenticated,
     AlreadyValidDASKeyset,
     NoSuchKeyset,
-    NotForked
+    NotForked,
+    RollupNotChanged
 } from "../libraries/Error.sol";
 import "./IBridge.sol";
 import "./IInboxBase.sol";
@@ -95,7 +96,9 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     function updateRollupAddress() external {
         if (msg.sender != IOwnable(rollup).owner())
             revert NotOwner(msg.sender, IOwnable(rollup).owner());
-        rollup = bridge.rollup();
+        IOwnable newRollup = bridge.rollup();
+        if (rollup == newRollup) revert RollupNotChanged();
+        rollup = newRollup;
     }
 
     function getTimeBounds() internal view virtual returns (TimeBounds memory) {

--- a/src/bridge/SequencerInbox.sol
+++ b/src/bridge/SequencerInbox.sol
@@ -91,6 +91,11 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         maxTimeVariation = maxTimeVariation_;
     }
 
+    /// @notice Allows the proxy owner to set the rollup address
+    function updateRollupAddress() external onlyDelegated onlyProxyOwner {
+        rollup = bridge.rollup();
+    }
+
     function getTimeBounds() internal view virtual returns (TimeBounds memory) {
         TimeBounds memory bounds;
         if (block.timestamp > maxTimeVariation.delaySeconds) {

--- a/src/libraries/Error.sol
+++ b/src/libraries/Error.sol
@@ -175,3 +175,6 @@ error AlreadyValidDASKeyset(bytes32);
 
 /// @dev Tried to use or invalidate an already invalid Data Availability Service keyset
 error NoSuchKeyset(bytes32);
+
+/// @dev Thrown when rollup is not updated with updateRollupAddress
+error RollupNotChanged();

--- a/src/libraries/Error.sol
+++ b/src/libraries/Error.sol
@@ -7,8 +7,11 @@ pragma solidity ^0.8.4;
 /// @dev Init was already called
 error AlreadyInit();
 
-/// Init was called with param set to zero that must be nonzero
+/// @dev Init was called with param set to zero that must be nonzero
 error HadZeroInit();
+
+/// @dev Thrown when post upgrade init validation fails
+error BadPostUpgradeInit();
 
 /// @dev Thrown when non owner tries to access an only-owner function
 /// @param sender The msg.sender who is not the owner
@@ -172,6 +175,3 @@ error AlreadyValidDASKeyset(bytes32);
 
 /// @dev Tried to use or invalidate an already invalid Data Availability Service keyset
 error NoSuchKeyset(bytes32);
-
-/// @dev Invalid rollup address is set
-error InvalidRollupSet(address);

--- a/src/libraries/Error.sol
+++ b/src/libraries/Error.sol
@@ -10,9 +10,6 @@ error AlreadyInit();
 /// @dev Init was called with param set to zero that must be nonzero
 error HadZeroInit();
 
-/// @dev Thrown when post upgrade init validation fails
-error BadPostUpgradeInit();
-
 /// @dev Thrown when non owner tries to access an only-owner function
 /// @param sender The msg.sender who is not the owner
 /// @param owner The owner address

--- a/src/libraries/Error.sol
+++ b/src/libraries/Error.sol
@@ -172,3 +172,6 @@ error AlreadyValidDASKeyset(bytes32);
 
 /// @dev Tried to use or invalidate an already invalid Data Availability Service keyset
 error NoSuchKeyset(bytes32);
+
+/// @dev Invalid rollup address is set
+error InvalidRollupSet(address);

--- a/src/mocks/BridgeStub.sol
+++ b/src/mocks/BridgeStub.sol
@@ -45,6 +45,10 @@ contract BridgeStub is IBridge, IEthBridge {
         revert("NOT_IMPLEMENTED");
     }
 
+    function updateRollupAddress(IOwnable) external pure {
+        revert("NOT_IMPLEMENTED");
+    }
+
     function enqueueDelayedMessage(
         uint8 kind,
         address sender,

--- a/src/rollup/AbsRollupEventInbox.sol
+++ b/src/rollup/AbsRollupEventInbox.sol
@@ -12,7 +12,7 @@ import "../libraries/ArbitrumChecker.sol";
 import "../bridge/IDelayedMessageProvider.sol";
 import "../libraries/DelegateCallAware.sol";
 import {INITIALIZATION_MSG_TYPE} from "../libraries/MessageTypes.sol";
-import {AlreadyInit, HadZeroInit} from "../libraries/Error.sol";
+import {AlreadyInit, HadZeroInit, RollupNotChanged} from "../libraries/Error.sol";
 
 /**
  * @title The inbox for rollup protocol events
@@ -41,7 +41,9 @@ abstract contract AbsRollupEventInbox is
     function updateRollupAddress() external {
         if (msg.sender != IOwnable(rollup).owner())
             revert NotOwner(msg.sender, IOwnable(rollup).owner());
-        rollup = address(bridge.rollup());
+        address newRollup = address(bridge.rollup());
+        if (rollup == newRollup) revert RollupNotChanged();
+        rollup = newRollup;
     }
 
     function rollupInitialized(uint256 chainId, string calldata chainConfig)

--- a/src/rollup/AbsRollupEventInbox.sol
+++ b/src/rollup/AbsRollupEventInbox.sol
@@ -37,6 +37,11 @@ abstract contract AbsRollupEventInbox is
         rollup = address(_bridge.rollup());
     }
 
+    /// @notice Allows the proxy owner to set the rollup address
+    function updateRollupAddress() external onlyDelegated onlyProxyOwner {
+        rollup = address(bridge.rollup());
+    }
+
     function rollupInitialized(uint256 chainId, string calldata chainConfig)
         external
         override

--- a/src/rollup/AbsRollupEventInbox.sol
+++ b/src/rollup/AbsRollupEventInbox.sol
@@ -37,8 +37,10 @@ abstract contract AbsRollupEventInbox is
         rollup = address(_bridge.rollup());
     }
 
-    /// @notice Allows the proxy owner to set the rollup address
-    function updateRollupAddress() external onlyDelegated onlyProxyOwner {
+    /// @notice Allows the rollup owner to sync the rollup address
+    function updateRollupAddress() external {
+        if (msg.sender != IOwnable(rollup).owner())
+            revert NotOwner(msg.sender, IOwnable(rollup).owner());
         rollup = address(bridge.rollup());
     }
 

--- a/src/rollup/IRollupEventInbox.sol
+++ b/src/rollup/IRollupEventInbox.sol
@@ -13,5 +13,7 @@ interface IRollupEventInbox {
 
     function rollup() external view returns (address);
 
+    function updateRollupAddress() external;
+
     function rollupInitialized(uint256 chainId, string calldata chainConfig) external;
 }

--- a/src/rollup/RollupUserLogic.sol
+++ b/src/rollup/RollupUserLogic.sol
@@ -234,7 +234,7 @@ abstract contract AbsRollupUserLogic is
      * and move it to the desired node.
      * @param stakerAddress Address of the staker whose stake is refunded
      */
-    function returnOldDeposit(address stakerAddress) external override onlyValidator whenNotPaused {
+    function returnOldDeposit(address stakerAddress) external override onlyValidator {
         require(latestStakedNode(stakerAddress) <= latestConfirmed(), "TOO_RECENT");
         requireUnchallengedStaker(stakerAddress);
         withdrawStaker(stakerAddress);
@@ -258,7 +258,7 @@ abstract contract AbsRollupUserLogic is
      * @notice Reduce the amount staked for the sender (difference between initial amount staked and target is creditted back to the sender).
      * @param target Target amount of stake for the staker. If this is below the current minimum, it will be set to minimum instead
      */
-    function reduceDeposit(uint256 target) external onlyValidator whenNotPaused {
+    function reduceDeposit(uint256 target) external onlyValidator {
         requireUnchallengedStaker(msg.sender);
         uint256 currentRequired = currentRequiredStake();
         if (target < currentRequired) {
@@ -659,7 +659,7 @@ contract RollupUserLogic is AbsRollupUserLogic, IRollupUser {
     /**
      * @notice Withdraw uncommitted funds owned by sender from the rollup chain
      */
-    function withdrawStakerFunds() external override onlyValidator whenNotPaused returns (uint256) {
+    function withdrawStakerFunds() external override onlyValidator returns (uint256) {
         uint256 amount = withdrawFunds(msg.sender);
         // This is safe because it occurs after all checks and effects
         // solhint-disable-next-line avoid-low-level-calls
@@ -731,7 +731,7 @@ contract ERC20RollupUserLogic is AbsRollupUserLogic, IRollupUserERC20 {
     /**
      * @notice Withdraw uncommitted funds owned by sender from the rollup chain
      */
-    function withdrawStakerFunds() external override onlyValidator whenNotPaused returns (uint256) {
+    function withdrawStakerFunds() external override onlyValidator returns (uint256) {
         uint256 amount = withdrawFunds(msg.sender);
         // This is safe because it occurs after all checks and effects
         require(IERC20Upgradeable(stakeToken).transfer(msg.sender, amount), "TRANSFER_FAILED");

--- a/src/rollup/RollupUserLogic.sol
+++ b/src/rollup/RollupUserLogic.sol
@@ -27,6 +27,11 @@ abstract contract AbsRollupUserLogic is
         _;
     }
 
+    modifier whenNotPausedOrDeprecated() {
+        require(!paused() || address(bridge.rollup()) != address(this), "PAUSED_AND_ACTIVE");
+        _;
+    }
+
     uint256 internal immutable deployTimeChainId = block.chainid;
 
     function _chainIdChanged() internal view returns (bool) {
@@ -225,11 +230,6 @@ abstract contract AbsRollupUserLogic is
         createNewNode(assertion, prevNode, prevNodeInboxMaxCount, expectedNodeHash);
 
         stakeOnNode(msg.sender, latestNodeCreated());
-    }
-
-    modifier whenNotPausedOrDeprecated() {
-        require(!paused() || address(bridge.rollup()) != address(this), "PAUSED_AND_ACTIVE");
-        _;
     }
 
     /**

--- a/src/rollup/RollupUserLogic.sol
+++ b/src/rollup/RollupUserLogic.sol
@@ -228,7 +228,7 @@ abstract contract AbsRollupUserLogic is
     }
 
     modifier whenNotPausedOrDeprecated() {
-        require(!paused() || address(bridge.rollup()) != address(this), "PAUSED_OR_NOT_DEPRECATED");
+        require(!paused() || address(bridge.rollup()) != address(this), "PAUSED_AND_ACTIVE");
         _;
     }
 

--- a/src/test-helpers/BridgeTester.sol
+++ b/src/test-helpers/BridgeTester.sol
@@ -74,7 +74,7 @@ contract BridgeTester is Initializable, DelegateCallAware, IBridge, IEthBridge {
         rollup = rollup_;
     }
 
-    function updateRollupAddress(IOwnable _rollup) external onlyDelegated onlyProxyOwner {
+    function updateRollupAddress(IOwnable _rollup) external {
         rollup = _rollup;
     }
 

--- a/src/test-helpers/BridgeTester.sol
+++ b/src/test-helpers/BridgeTester.sol
@@ -74,6 +74,10 @@ contract BridgeTester is Initializable, DelegateCallAware, IBridge, IEthBridge {
         rollup = rollup_;
     }
 
+    function updateRollupAddress(IOwnable _rollup) external onlyDelegated onlyProxyOwner {
+        rollup = _rollup;
+    }
+
     function activeOutbox() public view returns (address) {
         if (_activeOutbox == EMPTY_ACTIVEOUTBOX) return address(uint160(0));
         return _activeOutbox;

--- a/src/test-helpers/OutboxWithoutOptTester.sol
+++ b/src/test-helpers/OutboxWithoutOptTester.sol
@@ -54,6 +54,10 @@ contract OutboxWithoutOptTester is DelegateCallAware, IOutbox {
         emit SendRootUpdated(root, l2BlockHash);
     }
 
+    function updateRollupAddress() external onlyDelegated onlyProxyOwner {
+        rollup = address(bridge.rollup());
+    }
+
     /// @notice When l2ToL1Sender returns a nonzero address, the message was originated by an L2 account
     /// When the return value is zero, that means this is a system message
     /// @dev the l2ToL1Sender behaves as the tx.origin, the msg.sender should be validated to protect against reentrancies

--- a/test/contract/arbRollup.spec.ts
+++ b/test/contract/arbRollup.spec.ts
@@ -809,16 +809,22 @@ describe('ArbRollup', () => {
         .connect(await impersonateAccount(upgradeExecutor))
         .forceRefundStaker([await validators[3].getAddress()])
     ).wait()
+
+    await expect(
+      rollup.rollup.connect(validators[3]).withdrawStakerFunds()
+    ).to.be.revertedWith('PAUSED_AND_ACTIVE')
     // staker can only withdraw if rollup address changed when paused
     await bridge
       .connect(await impersonateAccount(rollup.rollup.address))
       .updateRollupAddress(ethers.constants.AddressZero)
+
     await (
       await rollup.rollup.connect(validators[3]).withdrawStakerFunds()
     ).wait()
     await rollupAdmin
       .connect(await impersonateAccount(upgradeExecutor))
       .resume()
+
     // restore rollup address
     await bridge
       .connect(await impersonateAccount(ethers.constants.AddressZero))

--- a/test/contract/arbRollup.spec.ts
+++ b/test/contract/arbRollup.spec.ts
@@ -823,6 +823,7 @@ describe('ArbRollup', () => {
       .connect(validators[1])
       .addToDeposit(await validators[1].getAddress(), { value: 5 })
 
+    await rollupAdmin.pause()
     await rollup.connect(validators[1]).reduceDeposit(5)
 
     const prevBalance = await validators[1].getBalance()
@@ -849,6 +850,7 @@ describe('ArbRollup', () => {
       .connect(validators[1])
       .returnOldDeposit(await validators[1].getAddress())
     // all stake is now removed
+    await rollupAdmin.resume()
   })
 
   it('should allow removing zombies', async function () {

--- a/test/contract/arbRollup.spec.ts
+++ b/test/contract/arbRollup.spec.ts
@@ -789,69 +789,85 @@ describe('ArbRollup', () => {
     await rollup.confirmNextNode(challengerNode)
   })
 
-  it('should add and remove stakes correctly', async function () {
-    /*
-      RollupUser functions that alter stake and their respective Core logic
+  it('allow force refund staker with pending node', async function () {
+    await (await rollupAdmin.pause()).wait();
+    await (await rollupAdmin.forceRefundStaker([await validators[1].getAddress()])).wait()
+    await (await rollup.rollup.connect(validators[1]).withdrawStakerFunds()).wait()
+    await (await rollupAdmin.resume()).wait();
 
-      user: newStake
-      core: createNewStake
-
-      user: addToDeposit
-      core: increaseStakeBy
-
-      user: reduceDeposit
-      core: reduceStakeTo
-
-      user: returnOldDeposit
-      core: withdrawStaker
-
-      user: withdrawStakerFunds
-      core: withdrawFunds
-    */
-
-    const initialStake = await rollup.rollup.amountStaked(
-      await validators[1].getAddress()
-    )
-
-    await rollup.connect(validators[1]).reduceDeposit(initialStake)
-
-    await expect(
-      rollup.connect(validators[1]).reduceDeposit(initialStake.add(1))
-    ).to.be.revertedWith('TOO_LITTLE_STAKE')
-
-    await rollup
-      .connect(validators[1])
-      .addToDeposit(await validators[1].getAddress(), { value: 5 })
-
-    await rollupAdmin.pause()
-    await rollup.connect(validators[1]).reduceDeposit(5)
-
-    const prevBalance = await validators[1].getBalance()
-    const prevWithdrawablefunds = await rollup.rollup.withdrawableFunds(
-      await validators[1].getAddress()
-    )
-
-    const tx = await rollup.rollup.connect(validators[1]).withdrawStakerFunds()
-    const receipt = await tx.wait()
-    const gasPaid = receipt.gasUsed.mul(receipt.effectiveGasPrice)
-
-    const postBalance = await validators[1].getBalance()
     const postWithdrawablefunds = await rollup.rollup.withdrawableFunds(
       await validators[1].getAddress()
     )
-
-    expect(postWithdrawablefunds).to.equal(0)
-    expect(postBalance.add(gasPaid)).to.equal(
-      prevBalance.add(prevWithdrawablefunds)
+    expect(postWithdrawablefunds, "withdrawable funds").to.equal(0)
+    const stake = await rollup.rollup.amountStaked(
+      await validators[1].getAddress()
     )
-
-    // this gets deposit and removes staker
-    await rollup.rollup
-      .connect(validators[1])
-      .returnOldDeposit(await validators[1].getAddress())
-    // all stake is now removed
-    await rollupAdmin.resume()
+    expect(stake, "amount staked").to.equal(0)
   })
+
+  // it('should add and remove stakes correctly', async function () {
+  //   /*
+  //     RollupUser functions that alter stake and their respective Core logic
+
+  //     user: newStake
+  //     core: createNewStake
+
+  //     user: addToDeposit
+  //     core: increaseStakeBy
+
+  //     user: reduceDeposit
+  //     core: reduceStakeTo
+
+  //     user: returnOldDeposit
+  //     core: withdrawStaker
+
+  //     user: withdrawStakerFunds
+  //     core: withdrawFunds
+  //   */
+
+  //   const initialStake = await rollup.rollup.amountStaked(
+  //     await validators[1].getAddress()
+  //   )
+
+  //   await rollup.connect(validators[1]).reduceDeposit(initialStake)
+
+  //   await expect(
+  //     rollup.connect(validators[1]).reduceDeposit(initialStake.add(1))
+  //   ).to.be.revertedWith('TOO_LITTLE_STAKE')
+
+  //   await rollup
+  //     .connect(validators[1])
+  //     .addToDeposit(await validators[1].getAddress(), { value: 5 })
+
+  //   await rollupAdmin.pause()
+  //   await rollup.connect(validators[1]).reduceDeposit(5)
+
+  //   const prevBalance = await validators[1].getBalance()
+  //   const prevWithdrawablefunds = await rollup.rollup.withdrawableFunds(
+  //     await validators[1].getAddress()
+  //   )
+
+  //   const tx = await rollup.rollup.connect(validators[1]).withdrawStakerFunds()
+  //   const receipt = await tx.wait()
+  //   const gasPaid = receipt.gasUsed.mul(receipt.effectiveGasPrice)
+
+  //   const postBalance = await validators[1].getBalance()
+  //   const postWithdrawablefunds = await rollup.rollup.withdrawableFunds(
+  //     await validators[1].getAddress()
+  //   )
+
+  //   expect(postWithdrawablefunds).to.equal(0)
+  //   expect(postBalance.add(gasPaid)).to.equal(
+  //     prevBalance.add(prevWithdrawablefunds)
+  //   )
+
+  //   // this gets deposit and removes staker
+  //   await rollup.rollup
+  //     .connect(validators[1])
+  //     .returnOldDeposit(await validators[1].getAddress())
+  //   // all stake is now removed
+  //   await rollupAdmin.resume()
+  // })
 
   it('should allow removing zombies', async function () {
     const zombieCount = (

--- a/test/contract/arbRollup.spec.ts
+++ b/test/contract/arbRollup.spec.ts
@@ -790,19 +790,23 @@ describe('ArbRollup', () => {
   })
 
   it('allow force refund staker with pending node', async function () {
-    await (await rollupAdmin.pause()).wait();
-    await (await rollupAdmin.forceRefundStaker([await validators[1].getAddress()])).wait()
-    await (await rollup.rollup.connect(validators[1]).withdrawStakerFunds()).wait()
-    await (await rollupAdmin.resume()).wait();
+    await (await rollupAdmin.pause()).wait()
+    await (
+      await rollupAdmin.forceRefundStaker([await validators[1].getAddress()])
+    ).wait()
+    await (
+      await rollup.rollup.connect(validators[1]).withdrawStakerFunds()
+    ).wait()
+    await (await rollupAdmin.resume()).wait()
 
     const postWithdrawablefunds = await rollup.rollup.withdrawableFunds(
       await validators[1].getAddress()
     )
-    expect(postWithdrawablefunds, "withdrawable funds").to.equal(0)
+    expect(postWithdrawablefunds, 'withdrawable funds').to.equal(0)
     const stake = await rollup.rollup.amountStaked(
       await validators[1].getAddress()
     )
-    expect(stake, "amount staked").to.equal(0)
+    expect(stake, 'amount staked').to.equal(0)
   })
 
   // it('should add and remove stakes correctly', async function () {


### PR DESCRIPTION
This PR included 2 changes that should only affect privileged methods

- [x] Allow rollup admin to update rollup addresses in Bridge contracts, and synchronizing those changes to Outbox, RollupEventInbox, and Sequencer Inbox. These changes are audited as part of BOLD in https://github.com/OffchainLabs/bold/pull/340 but for proxy admin instead of rollup admin. Allowing rollup admin to call those function make the upgrade executor being able to call those function easier (or otherwise would require a upgradeAndCall via the ProxyAdmin contract).

- [x] Introduce `whenNotPausedOrDeprecated` modifier, which allow validator to withdraw their stake when the rollup is deprecated by changing the rollup address in the bridge to something else

Superseding
* https://github.com/OffchainLabs/nitro-contracts/pull/54
* https://github.com/OffchainLabs/nitro-contracts/pull/48