### PR TITLE
add pausable functionality directly Bridge

### DIFF
--- a/src/bridge/Bridge.sol
+++ b/src/bridge/Bridge.sol
@@ -172,7 +172,7 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
         uint8 kind,
         address sender,
         bytes32 messageDataHash
-    ) external payable whenNotPaused returns (uint256) {
+    ) external payable returns (uint256) {
         if (!allowedDelayedInboxesMap[msg.sender].allowed) revert NotDelayedInbox(msg.sender);
         return
             addMessageToDelayedAccumulator(

--- a/src/bridge/Bridge.sol
+++ b/src/bridge/Bridge.sol
@@ -78,13 +78,13 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
     }
 
     modifier whenNotPaused() {
-        if(paused()){
+        if (paused()) {
             revert Paused();
         }
         _;
     }
     modifier whenPaused() {
-        if(!paused()){
+        if (!paused()) {
             revert Unpaused();
         }
         _;
@@ -172,7 +172,7 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
         uint8 kind,
         address sender,
         bytes32 messageDataHash
-    ) external whenNotPaused payable returns (uint256) {
+    ) external payable whenNotPaused returns (uint256) {
         if (!allowedDelayedInboxesMap[msg.sender].allowed) revert NotDelayedInbox(msg.sender);
         return
             addMessageToDelayedAccumulator(
@@ -301,6 +301,7 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
         _paused = true;
         emit BridgePaused(msg.sender);
     }
+
     function unpause() external onlyRollupOrOwner whenPaused {
         _paused = false;
         emit BridgeUnpaused(msg.sender);
@@ -309,5 +310,4 @@ contract Bridge is Initializable, DelegateCallAware, IBridge {
     function paused() public view returns (bool) {
         return _paused;
     }
-
 }

--- a/src/bridge/IBridge.sol
+++ b/src/bridge/IBridge.sol
@@ -32,6 +32,11 @@ interface IBridge {
 
     event SequencerInboxUpdated(address newSequencerInbox);
 
+    event BridgePaused(address account);
+
+    event BridgeUnpaused(address account);
+
+
     function allowedDelayedInboxList(uint256) external returns (address);
 
     function allowedOutboxList(uint256) external returns (address);
@@ -108,6 +113,10 @@ interface IBridge {
     function setDelayedInbox(address inbox, bool enabled) external;
 
     function setOutbox(address inbox, bool enabled) external;
+
+   function pause() external;
+
+    function unpause() external;
 
     // ---------- initializer ----------
 

--- a/src/bridge/IBridge.sol
+++ b/src/bridge/IBridge.sol
@@ -36,7 +36,6 @@ interface IBridge {
 
     event BridgeUnpaused(address account);
 
-
     function allowedDelayedInboxList(uint256) external returns (address);
 
     function allowedOutboxList(uint256) external returns (address);

--- a/src/bridge/IBridge.sol
+++ b/src/bridge/IBridge.sol
@@ -113,7 +113,7 @@ interface IBridge {
 
     function setOutbox(address inbox, bool enabled) external;
 
-   function pause() external;
+    function pause() external;
 
     function unpause() external;
 

--- a/src/libraries/Error.sol
+++ b/src/libraries/Error.sol
@@ -72,6 +72,9 @@ error AlreadyUnpaused();
 /// @dev The contract is paused
 error Paused();
 
+/// @dev The contract is unpaused
+error Unpaused();
+
 /// @dev msg.value sent to the inbox isn't high enough
 error InsufficientValue(uint256 expected, uint256 actual);
 

--- a/src/mocks/BridgeStub.sol
+++ b/src/mocks/BridgeStub.sol
@@ -174,6 +174,10 @@ contract BridgeStub is IBridge {
         revert("NOT_IMPLEMENTED");
     }
 
+    function pause() external {}
+
+    function unpause() external {}
+
     function acceptFundsFromOldBridge() external payable {}
 
     function initialize(IOwnable) external pure {

--- a/src/test-helpers/BridgeTester.sol
+++ b/src/test-helpers/BridgeTester.sol
@@ -232,6 +232,10 @@ contract BridgeTester is Initializable, DelegateCallAware, IBridge {
     function sequencerMessageCount() external view override returns (uint256) {
         return sequencerInboxAccs.length;
     }
+    
+    function pause() external {}
+
+    function unpause() external {}
 
     receive() external payable {}
 

--- a/src/test-helpers/BridgeTester.sol
+++ b/src/test-helpers/BridgeTester.sol
@@ -232,7 +232,7 @@ contract BridgeTester is Initializable, DelegateCallAware, IBridge {
     function sequencerMessageCount() external view override returns (uint256) {
         return sequencerInboxAccs.length;
     }
-    
+
     function pause() external {}
 
     function unpause() external {}


### PR DESCRIPTION
Currently pausing batch posting requires all batchPosters be removed in the sequencer inbox, pausing outbox execution requires all allowed outboxes be removed in the bridge, and pausing force inclusion isn't possible / requires a proxy upgrade. This makes those things possible more cleanly.
- Also removed `acceptFundsFromOldBridge ` while at it.
- AFAIK upgrading to inherit OZ's PausableUpgradeable would mess up the storage layout, so we just include the pause methods directly. 