### PR TITLE
Add DepositMessageDelivered event

### DIFF
--- a/src/bridge/AbsBridge.sol
+++ b/src/bridge/AbsBridge.sol
@@ -203,6 +203,7 @@ abstract contract AbsBridge is Initializable, DelegateCallAware, IBridge {
             baseFeeL1,
             blockTimestamp
         );
+        emit MessageDeliveredV2(kind, sender);
         return count;
     }
 

--- a/src/bridge/AbsBridge.sol
+++ b/src/bridge/AbsBridge.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.4;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
+import {L1MessageType_ethDeposit} from "../libraries/MessageTypes.sol";
 
 import {
     NotContract,
@@ -203,7 +204,9 @@ abstract contract AbsBridge is Initializable, DelegateCallAware, IBridge {
             baseFeeL1,
             blockTimestamp
         );
-        emit MessageDeliveredV2(kind, sender);
+        if (kind == L1MessageType_ethDeposit) {
+            emit DepositMessageDelivered(sender);
+        }
         return count;
     }
 

--- a/src/bridge/IBridge.sol
+++ b/src/bridge/IBridge.sol
@@ -19,7 +19,7 @@ interface IBridge {
         uint64 timestamp
     );
 
-    event MessageDeliveredV2(uint8 indexed kind, address indexed sender);
+    event DepositMessageDelivered(address indexed sender);
 
     event BridgeCallTriggered(
         address indexed outbox,

--- a/src/bridge/IBridge.sol
+++ b/src/bridge/IBridge.sol
@@ -19,6 +19,8 @@ interface IBridge {
         uint64 timestamp
     );
 
+    event MessageDeliveredV2(uint8 indexed kind, address indexed sender);
+
     event BridgeCallTriggered(
         address indexed outbox,
         address indexed to,


### PR DESCRIPTION
This event allows bridges to efficiently query the deposit history for an address without requiring an external indexer.