### PR TITLE
2028 change date

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -10,7 +10,7 @@ Parameters
 Licensor:             Offchain Labs
 
 Licensed Work:        Arbitrum Nitro Contracts
-                      The Licensed Work is (c) 2021-2023 Offchain Labs
+                      The Licensed Work is (c) 2021-2024 Offchain Labs
 
 Additional Use Grant: You may use the Licensed Work in a production environment solely
                       to provide a point of interface to permit end users or applications
@@ -30,7 +30,7 @@ Additional Use Grant: You may use the Licensed Work in a production environment 
 
 
 
-Change Date:          Dec 31, 2027
+Change Date:          Dec 31, 2028
 
 Change License:       Apache License Version 2.0
 


### PR DESCRIPTION
Updates the BSL change date to 2028, ensuring that the 4 year delay is not cut short.