### PR TITLE
Add WAVM KZG preimage proof

### DIFF
--- a/src/osp/OneStepProverHostIo.sol
+++ b/src/osp/OneStepProverHostIo.sol
@@ -182,6 +182,8 @@ contract OneStepProverHostIo is IOneStepProver {
 
             require(proofType == 0, "UNKNOWN_PREIMAGE_PROOF");
 
+            // kzgProof should be a valid input to the EIP-4844 point evaluation precompile at address 0x0A.
+            // It should prove the preimageOffset/32'th word of the machine's requested KZG commitment.
             bytes calldata kzgProof = proof[proofOffset:];
 
             require(bytes32(kzgProof[:32]) == leafContents, "KZG_PROOF_WRONG_HASH");

--- a/src/osp/OneStepProverHostIo.sol
+++ b/src/osp/OneStepProverHostIo.sol
@@ -185,7 +185,7 @@ contract OneStepProverHostIo is IOneStepProver {
                 uint256 bitReversedIndex = 0;
                 // preimageOffset was required to be 32 byte aligned above
                 uint256 tmp = preimageOffset / 32;
-                for (uint256 i = 1; i < fieldElementsPerBlob; i *= 2) {
+                for (uint256 i = 1; i < fieldElementsPerBlob; i <<= 1) {
                     bitReversedIndex <<= 1;
                     if (tmp & 1 == 1) {
                         bitReversedIndex |= 1;

--- a/src/osp/OneStepProverHostIo.sol
+++ b/src/osp/OneStepProverHostIo.sol
@@ -108,18 +108,13 @@ contract OneStepProverHostIo is IOneStepProver {
 
     // Computes b**e % m
     // Really pure but the Solidity compiler sees the staticcall and requires view
-    function modExp256(uint256 b, uint256 e, uint256 m) internal view returns (uint256) {
-        bytes memory modExpInput = abi.encode(
-            32,
-            32,
-            32,
-            b,
-            e,
-            m
-        );
-        (bool modexpSuccess, bytes memory modExpOutput) = address(0x05).staticcall(
-            modExpInput
-        );
+    function modExp256(
+        uint256 b,
+        uint256 e,
+        uint256 m
+    ) internal view returns (uint256) {
+        bytes memory modExpInput = abi.encode(32, 32, 32, b, e, m);
+        (bool modexpSuccess, bytes memory modExpOutput) = address(0x05).staticcall(modExpInput);
         require(modexpSuccess, "MODEXP_FAILED");
         require(modExpOutput.length == 32, "MODEXP_WRONG_LENGTH");
         return uint256(bytes32(modExpOutput));

--- a/src/osp/OneStepProverHostIo.sol
+++ b/src/osp/OneStepProverHostIo.sol
@@ -202,7 +202,7 @@ contract OneStepProverHostIo is IOneStepProver {
             // validate a user-supplied root of unity.
             require(blsModulus == BLS_MODULUS, "UNKNOWN_BLS_MODULUS");
 
-            // If preimageOffset is greater than the blob size, leave extracted empty and call it here.
+            // If preimageOffset is greater than or equal to the blob size, leave extracted empty and call it here.
             if (preimageOffset < fieldElementsPerBlob * 32) {
                 // We need to compute what point the polynomial should be evaluated at to get the right part of the preimage.
                 // KZG commitments use a bit reversal permutation to order the roots of unity.


### PR DESCRIPTION
This adds a new type of preimage proof for Ethereum versioned hashes using the new EIP-4844 point evaluation precompile which will be introduced in Cancun along with blobs themselves. It's fine to deploy this before then though, because it'll just revert with "KZG_PRECOMPILE_MISSING" if the new preimage type is attempted to be proven before it's ready (and these preimages shouldn't even be attempted to be proven until 4844 is being utilized anyways).

This PR also requires that the WAVM ReadPreImage opcode be called with a preimage offset that's a multiple of 32, which was already what was done in practice before this.