### PR TITLE
Include blob cost in extraGas field of batch posting reports

### DIFF
--- a/test/contract/sequencerInbox.spec.4844.ts
+++ b/test/contract/sequencerInbox.spec.4844.ts
@@ -523,8 +523,6 @@ describe('SequencerInbox', async () => {
       '0x' + inboxMsgDeliveredEvent.data.substring(234, 298)
     const spendingExtraGas =
       '0x' + inboxMsgDeliveredEvent.data.substring(298, 314)
-    const spendingBlobBasefee =
-      '0x' + inboxMsgDeliveredEvent.data.substring(314, 378)
 
     expect(
       BigNumber.from(spendingTimestamp).eq(blockTimestamp),
@@ -547,13 +545,8 @@ describe('SequencerInbox', async () => {
       `spending basefee: ${BigNumber.from(spendingBlockBaseFee).toString()}`
     ).to.eq(true)
     expect(
-      BigNumber.from(spendingExtraGas).eq(0),
+      BigNumber.from(spendingExtraGas).gt(0), // blob spending is normalized into extra gas
       `spending extra gas: ${BigNumber.from(spendingExtraGas).toString()}`
-    ).to.eq(true)
-    // we expect a very low - 1 - basefee since we havent sent many blobs
-    expect(
-      BigNumber.from(spendingBlobBasefee).eq(1),
-      `spending blob basefee: ${BigNumber.from(spendingBlobBasefee).toString()}`
     ).to.eq(true)
   })
 

--- a/test/foundry/SequencerInbox.t.sol
+++ b/test/foundry/SequencerInbox.t.sol
@@ -108,7 +108,8 @@ contract SequencerInboxTest is Test {
             sequenceNumber,
             block.basefee,
             uint64(0),
-            uint256(0)
+            uint256(0),
+            uint64(0)
         );
         bytes32 beforeAcc = bytes32(0);
         bytes32 delayedAcc = bridge.delayedInboxAccs(delayedMessagesRead - 1);
@@ -137,7 +138,7 @@ contract SequencerInboxTest is Test {
         // sequencer batch delivered
         vm.expectEmit();
         emit SequencerBatchDelivered(
-            sequenceNumber, 
+            sequenceNumber,
             beforeAcc,
             afterAcc,
             delayedAcc,

--- a/test/foundry/SequencerInbox.t.sol
+++ b/test/foundry/SequencerInbox.t.sol
@@ -107,8 +107,6 @@ contract SequencerInboxTest is Test {
             dataHash,
             sequenceNumber,
             block.basefee,
-            uint64(0),
-            uint256(0),
             uint64(0)
         );
         bytes32 beforeAcc = bytes32(0);


### PR DESCRIPTION
Instead of adding a new field for the blob basefee, this PR adds the blob cost into the existing extraGas field.

The main disadvantage of this PR is that ArbOS will think that the sequencer paid for the blob hash list data as tx data, but I think that should be a small error.