### PR TITLE
Use 0x50 as the header byte for 4844 batches

### DIFF
--- a/src/bridge/ISequencerInbox.sol
+++ b/src/bridge/ISequencerInbox.sol
@@ -47,6 +47,12 @@ interface ISequencerInbox is IDelayedMessageProvider {
     // solhint-disable-next-line func-name-mixedcase
     function HEADER_LENGTH() external view returns (uint256);
 
+    /// @dev If the first batch data byte after the header has this bit set,
+    ///      the sequencer inbox has authenticated the data. Currently only used for 4844 blob support.
+    ///      See: https://github.com/OffchainLabs/nitro/blob/69de0603abf6f900a4128cab7933df60cad54ded/arbstate/das_reader.go
+    // solhint-disable-next-line func-name-mixedcase
+    function DATA_AUTHENTICATED_FLAG() external view returns (bytes1);
+
     /// @dev If the first data byte after the header has this bit set,
     ///      then the batch data is to be found in 4844 data blobs
     ///      See: https://github.com/OffchainLabs/nitro/blob/69de0603abf6f900a4128cab7933df60cad54ded/arbstate/das_reader.go

--- a/src/bridge/SequencerInbox.sol
+++ b/src/bridge/SequencerInbox.sol
@@ -62,7 +62,10 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
     uint256 public constant HEADER_LENGTH = 40;
 
     /// @inheritdoc ISequencerInbox
-    bytes1 public constant DATA_BLOB_HEADER_FLAG = 0x40;
+    bytes1 public constant DATA_AUTHENTICATED_FLAG = 0x40;
+
+    /// @inheritdoc ISequencerInbox
+    bytes1 public constant DATA_BLOB_HEADER_FLAG = DATA_AUTHENTICATED_FLAG | 0x10;
 
     /// @inheritdoc ISequencerInbox
     bytes1 public constant DAS_MESSAGE_HEADER_FLAG = 0x80;
@@ -406,7 +409,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         );
     }
 
-    function addSequencerL2BatchFromBlob(
+    function addSequencerL2BatchFromBlobs(
         uint256 sequenceNumber,
         uint256 afterDelayedMessagesRead,
         IGasRefunder gasRefunder,

--- a/test/contract/sequencerInbox.spec.4844.ts
+++ b/test/contract/sequencerInbox.spec.4844.ts
@@ -472,7 +472,7 @@ describe('SequencerInbox', async () => {
       sequencerInbox.address,
       ['0x0142', '0x0143'],
       sequencerInbox.interface.encodeFunctionData(
-        'addSequencerL2BatchFromBlob',
+        'addSequencerL2BatchFromBlobs',
         [
           sequenceNumber,
           afterDelayedMessagesRead,

--- a/test/contract/toolkit4844.ts
+++ b/test/contract/toolkit4844.ts
@@ -11,7 +11,7 @@ const wait = async (ms: number) =>
   })
 
 export class Toolkit4844 {
-  public static DATA_BLOB_HEADER_FLAG = '0x40'
+  public static DATA_BLOB_HEADER_FLAG = '0x50' // 0x40 | 0x10
 
   public static postDataToGeth(body: any): Promise<any> {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
This leaves other possibilities open for the DATA_AUTHENTICATED_FLAG.

Also renames `addSequencerL2BatchFromBlob` to `addSequencerL2BatchFromBlobs` (plural) since it can use multiple blobs.