### PR TITLE
fix: 3074 support

### DIFF
--- a/src/bridge/AbsInbox.sol
+++ b/src/bridge/AbsInbox.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.4;
 
 import {
     DataTooLarge,
+    Deprecated,
     GasLimitTooLarge,
     InsufficientValue,
     InsufficientSubmissionCost,
@@ -131,19 +132,8 @@ abstract contract AbsInbox is DelegateCallAware, PausableUpgradeable, IInboxBase
     }
 
     /// @inheritdoc IInboxBase
-    function sendL2MessageFromOrigin(bytes calldata messageData)
-        external
-        whenNotPaused
-        onlyAllowed
-        returns (uint256)
-    {
-        if (_chainIdChanged()) revert L1Forked();
-        // solhint-disable-next-line avoid-tx-origin
-        if (msg.sender != tx.origin) revert NotOrigin();
-        if (messageData.length > maxDataSize) revert DataTooLarge(messageData.length, maxDataSize);
-        uint256 msgNum = _deliverToBridge(L2_MSG, msg.sender, keccak256(messageData), 0);
-        emit InboxMessageDeliveredFromOrigin(msgNum);
-        return msgNum;
+    function sendL2MessageFromOrigin(bytes calldata) external pure returns (uint256) {
+        revert Deprecated();
     }
 
     /// @inheritdoc IInboxBase

--- a/src/bridge/IInboxBase.sol
+++ b/src/bridge/IInboxBase.sol
@@ -16,12 +16,8 @@ interface IInboxBase is IDelayedMessageProvider {
 
     function maxDataSize() external view returns (uint256);
 
-    /**
-     * @notice Send a generic L2 message to the chain
-     * @dev This method is an optimization to avoid having to emit the entirety of the messageData in a log. Instead validators are expected to be able to parse the data from the transaction's input
-     * @param messageData Data of the message being sent
-     */
-    function sendL2MessageFromOrigin(bytes calldata messageData) external returns (uint256);
+    /// @dev Deprecated due to EIP-3074
+    function sendL2MessageFromOrigin(bytes calldata) external returns (uint256);
 
     /**
      * @notice Send a generic L2 message to the chain

--- a/src/bridge/ISequencerInbox.sol
+++ b/src/bridge/ISequencerInbox.sol
@@ -171,6 +171,7 @@ interface ISequencerInbox is IDelayedMessageProvider {
 
     // ---------- BatchPoster functions ----------
 
+    /// @dev Deprecated, kept for abi generation and will be removed in the future
     function addSequencerL2BatchFromOrigin(
         uint256 sequenceNumber,
         bytes calldata data,
@@ -178,6 +179,7 @@ interface ISequencerInbox is IDelayedMessageProvider {
         IGasRefunder gasRefunder
     ) external;
 
+    /// @dev Will be deprecated due to EIP-3074, use `addSequencerL2Batch` instead
     function addSequencerL2BatchFromOrigin(
         uint256 sequenceNumber,
         bytes calldata data,
@@ -217,6 +219,7 @@ interface ISequencerInbox is IDelayedMessageProvider {
 
     /// @dev    Proves message delays, updates delay buffers, and posts an L2 batch with calldata posted from an EOA.
     ///         DelayProof proves the delay of the message and syncs the delay buffer.
+    ///         Will be deprecated due to EIP-3074, use `addSequencerL2BatchDelayProof` instead
     function addSequencerL2BatchFromOriginDelayProof(
         uint256 sequenceNumber,
         bytes calldata data,

--- a/src/bridge/SequencerInbox.sol
+++ b/src/bridge/SequencerInbox.sol
@@ -354,7 +354,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         );
     }
 
-    /// @dev Deprecated, kept for abi generation and will be removed in the future
+    /// @inheritdoc ISequencerInbox
     function addSequencerL2BatchFromOrigin(
         uint256,
         bytes calldata,

--- a/test/foundry/AbsInbox.t.sol
+++ b/test/foundry/AbsInbox.t.sol
@@ -187,50 +187,9 @@ abstract contract AbsInboxTest is Test {
         inb.initialize(bridge, ISequencerInbox(seqInbox));
     }
 
-    function test_sendL2MessageFromOrigin() public {
-        // L2 msg params
-        bytes memory data = abi.encodePacked("some msg");
-
-        // expect event
-        vm.expectEmit(true, true, true, true);
-        emit InboxMessageDeliveredFromOrigin(0);
-
-        // send L2 msg -> tx.origin == msg.sender
-        vm.prank(user, user);
-        uint256 msgNum = inbox.sendL2MessageFromOrigin(data);
-
-        //// checks
-        assertEq(msgNum, 0, "Invalid msgNum");
-        assertEq(bridge.delayedMessageCount(), 1, "Invalid delayed message count");
-    }
-
-    function test_sendL2MessageFromOrigin_revert_WhenPaused() public {
-        vm.prank(rollup);
-        inbox.pause();
-
-        vm.expectRevert("Pausable: paused");
+    function test_sendL2MessageFromOrigin_revert() public {
+        vm.expectRevert(abi.encodeWithSelector(Deprecated.selector));
         vm.prank(user);
-        inbox.sendL2MessageFromOrigin(abi.encodePacked("some msg"));
-    }
-
-    function test_sendL2MessageFromOrigin_revert_NotAllowed() public {
-        vm.prank(rollup);
-        inbox.setAllowListEnabled(true);
-
-        vm.expectRevert(abi.encodeWithSelector(NotAllowedOrigin.selector, user));
-        vm.prank(user, user);
-        inbox.sendL2MessageFromOrigin(abi.encodePacked("some msg"));
-    }
-
-    function test_sendL2MessageFromOrigin_revert_L1Forked() public {
-        vm.chainId(10);
-        vm.expectRevert(abi.encodeWithSelector(L1Forked.selector));
-        vm.prank(user, user);
-        inbox.sendL2MessageFromOrigin(abi.encodePacked("some msg"));
-    }
-
-    function test_sendL2MessageFromOrigin_revert_NotOrigin() public {
-        vm.expectRevert(abi.encodeWithSelector(NotOrigin.selector));
         inbox.sendL2MessageFromOrigin(abi.encodePacked("some msg"));
     }
 


### PR DESCRIPTION
This PR

- [x] Add deprecation notice to function affected by EIP-3074
- [x] Deprecate `sendL2MessageFromOrigin`
  - This is a breaking change but should be fine because as of now only an EOA can call this method, so we are not going to run into issue like breaking an immutable contract. Alternatively, we can have this entrypoint call into the non-origin entrypoint but may require changes in the nitro node to locate the data properly.

SequencerInbox `fromOrigin` entrypoints are not removed yet, it will be fixed before EIP-3074 ship and when we have more clarity on its implementation. Since those entrypoints are only callable by the sequencer it pose less risk than the permissionless `sendL2MessageFromOrigin` and hence not removed in this PR for now.