### PR TITLE
refactor: move machine hash logic to osp

### DIFF
--- a/src/challenge/ChallengeLib.sol
+++ b/src/challenge/ChallengeLib.sol
@@ -48,51 +48,6 @@ library ChallengeLib {
         return challenge.timeUsedSinceLastMove() > challenge.current.timeLeft;
     }
 
-    function getStartMachineHash(bytes32 globalStateHash, bytes32 wasmModuleRoot)
-        internal
-        pure
-        returns (bytes32)
-    {
-        // Start the value stack with the function call ABI for the entrypoint
-        Value[] memory startingValues = new Value[](3);
-        startingValues[0] = ValueLib.newRefNull();
-        startingValues[1] = ValueLib.newI32(0);
-        startingValues[2] = ValueLib.newI32(0);
-        ValueArray memory valuesArray = ValueArray({inner: startingValues});
-        ValueStack memory values = ValueStack({proved: valuesArray, remainingHash: 0});
-        ValueStack memory internalStack;
-        StackFrameWindow memory frameStack;
-
-        Machine memory mach = Machine({
-            status: MachineStatus.RUNNING,
-            valueStack: values,
-            internalStack: internalStack,
-            frameStack: frameStack,
-            globalStateHash: globalStateHash,
-            moduleIdx: 0,
-            functionIdx: 0,
-            functionPc: 0,
-            modulesRoot: wasmModuleRoot
-        });
-        return mach.hash();
-    }
-
-    function getEndMachineHash(MachineStatus status, bytes32 globalStateHash)
-        internal
-        pure
-        returns (bytes32)
-    {
-        if (status == MachineStatus.FINISHED) {
-            return keccak256(abi.encodePacked("Machine finished:", globalStateHash));
-        } else if (status == MachineStatus.ERRORED) {
-            return keccak256(abi.encodePacked("Machine errored:"));
-        } else if (status == MachineStatus.TOO_FAR) {
-            return keccak256(abi.encodePacked("Machine too far:"));
-        } else {
-            revert("BAD_BLOCK_STATUS");
-        }
-    }
-
     function extractChallengeSegment(SegmentSelection calldata selection)
         internal
         pure

--- a/src/challenge/ChallengeManager.sol
+++ b/src/challenge/ChallengeManager.sol
@@ -233,11 +233,8 @@ contract ChallengeManager is DelegateCallAware, IChallengeManager {
         }
 
         bytes32[] memory segments = new bytes32[](2);
-        segments[0] = ChallengeLib.getStartMachineHash(
-            globalStateHashes[0],
-            challenge.wasmModuleRoot
-        );
-        segments[1] = ChallengeLib.getEndMachineHash(machineStatuses[1], globalStateHashes[1]);
+        segments[0] = osp.getStartMachineHash(globalStateHashes[0], challenge.wasmModuleRoot);
+        segments[1] = osp.getEndMachineHash(machineStatuses[1], globalStateHashes[1]);
 
         challenge.mode = ChallengeLib.ChallengeMode.EXECUTION;
 

--- a/src/osp/IOneStepProofEntry.sol
+++ b/src/osp/IOneStepProofEntry.sol
@@ -11,6 +11,16 @@ library OneStepProofEntryLib {
 }
 
 interface IOneStepProofEntry {
+    function getStartMachineHash(bytes32 globalStateHash, bytes32 wasmModuleRoot)
+        external
+        pure
+        returns (bytes32);
+
+    function getEndMachineHash(MachineStatus status, bytes32 globalStateHash)
+        external
+        pure
+        returns (bytes32);
+
     function proveOneStep(
         ExecutionContext calldata execCtx,
         uint256 machineStep,

--- a/src/osp/OneStepProofEntry.sol
+++ b/src/osp/OneStepProofEntry.sol
@@ -31,6 +31,53 @@ contract OneStepProofEntry is IOneStepProofEntry {
         proverHostIo = proverHostIo_;
     }
 
+    // Copied from ChallengeLib.sol
+    function getStartMachineHash(bytes32 globalStateHash, bytes32 wasmModuleRoot)
+        external
+        pure
+        returns (bytes32)
+    {
+        // Start the value stack with the function call ABI for the entrypoint
+        Value[] memory startingValues = new Value[](3);
+        startingValues[0] = ValueLib.newRefNull();
+        startingValues[1] = ValueLib.newI32(0);
+        startingValues[2] = ValueLib.newI32(0);
+        ValueArray memory valuesArray = ValueArray({inner: startingValues});
+        ValueStack memory values = ValueStack({proved: valuesArray, remainingHash: 0});
+        ValueStack memory internalStack;
+        StackFrameWindow memory frameStack;
+
+        Machine memory mach = Machine({
+            status: MachineStatus.RUNNING,
+            valueStack: values,
+            internalStack: internalStack,
+            frameStack: frameStack,
+            globalStateHash: globalStateHash,
+            moduleIdx: 0,
+            functionIdx: 0,
+            functionPc: 0,
+            modulesRoot: wasmModuleRoot
+        });
+        return mach.hash();
+    }
+
+    // Copied from ChallengeLib.sol
+    function getEndMachineHash(MachineStatus status, bytes32 globalStateHash)
+        external
+        pure
+        returns (bytes32)
+    {
+        if (status == MachineStatus.FINISHED) {
+            return keccak256(abi.encodePacked("Machine finished:", globalStateHash));
+        } else if (status == MachineStatus.ERRORED) {
+            return keccak256(abi.encodePacked("Machine errored:"));
+        } else if (status == MachineStatus.TOO_FAR) {
+            return keccak256(abi.encodePacked("Machine too far:"));
+        } else {
+            revert("BAD_BLOCK_STATUS");
+        }
+    }
+
     function proveOneStep(
         ExecutionContext calldata execCtx,
         uint256 machineStep,

--- a/test/signatures/OneStepProofEntry
+++ b/test/signatures/OneStepProofEntry
@@ -1,0 +1,9 @@
+{
+  "getEndMachineHash(uint8,bytes32)": "d8558b87",
+  "getStartMachineHash(bytes32,bytes32)": "04997be4",
+  "proveOneStep((uint256,address),uint256,bytes32,bytes)": "5d3adcfb",
+  "prover0()": "30a5509f",
+  "proverHostIo()": "5f52fd7c",
+  "proverMath()": "66e5d9c3",
+  "proverMem()": "1f128bc0"
+}

--- a/test/signatures/test-sigs.bash
+++ b/test/signatures/test-sigs.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 output_dir="./test/signatures"
-for CONTRACTNAME in Bridge Inbox Outbox RollupCore RollupUserLogic RollupAdminLogic SequencerInbox ChallengeManager ERC20Bridge ERC20Inbox ERC20Outbox BridgeCreator DeployHelper RollupCreator
+for CONTRACTNAME in Bridge Inbox Outbox RollupCore RollupUserLogic RollupAdminLogic SequencerInbox ChallengeManager ERC20Bridge ERC20Inbox ERC20Outbox BridgeCreator DeployHelper RollupCreator OneStepProofEntry
 do
     echo "Checking for signature changes in $CONTRACTNAME"
     [ -f "$output_dir/$CONTRACTNAME" ] && mv "$output_dir/$CONTRACTNAME" "$output_dir/$CONTRACTNAME-old"


### PR DESCRIPTION
This PR move `getStartMachineHash` and `getEndMachineHash` from `ChallengeLib` to `OneStepProofEntry`, this change would make the `ChallengeManager` not compatible with previously deployed OSP.