### PR TITLE
Fix the nitro CI builds.

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -14,6 +14,8 @@ src = 'yul'
 out = 'out/yul'
 libs = ['node_modules', 'lib']
 cache_path  = 'forge-cache/yul'
+remappings = []
+auto_detect_remappings = false
 
 [fmt]
 number_underscore = 'thousands'

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,0 @@
-ds-test/=lib/forge-std/lib/ds-test/src/
-forge-std/=lib/forge-std/src/
-
-@openzeppelin/contracts/=node_modules/@openzeppelin/contracts/
-@openzeppelin/contracts-upgradeable/=node_modules/@openzeppelin/contracts-upgradeable/


### PR DESCRIPTION
For some reason, the master branch of nitro won't build the contracts if there are any remappings specified for a yul build.

This change removes the remappings for the yul build.