### PR TITLE
feat: Use SafeApprove for ERC20Inbox Initialization

### DIFF
--- a/src/bridge/ERC20Inbox.sol
+++ b/src/bridge/ERC20Inbox.sol
@@ -33,7 +33,7 @@ contract ERC20Inbox is AbsInbox, IERC20Inbox {
 
         // inbox holds native token in transit used to pay for retryable tickets, approve bridge to use it
         address nativeToken = IERC20Bridge(address(bridge)).nativeToken();
-        IERC20(nativeToken).approve(address(bridge), type(uint256).max);
+        IERC20(nativeToken).safeApprove(address(bridge), type(uint256).max);
     }
 
     /// @inheritdoc IERC20Inbox


### PR DESCRIPTION
In `ERC20Inbox.sol` there is an approve which is just a plain IERC20 function. However, in standard with the rest of the codebase, using a `safeApprove` would allow Tether and non-standard token support. It is already within the OZ library used extensively everywhere else, and would make my life easier. 

```
copypaste@copypastes-MacBook-Pro nitro-contracts % grep -r ".approve(" src
src/bridge/ERC20Inbox.sol:        IERC20(nativeToken).approve(address(bridge), type(uint256).max);
```

It is also the only instance where this is true, so its a relatively simple patch that opens up the use for Tether as a native token. Thank you for your time and understanding . Signed CLA but if you want to make your own branch + force merge go ahead