### PR TITLE
ci: remove push hook

### DIFF
--- a/.github/workflows/audit-ci.yml
+++ b/.github/workflows/audit-ci.yml
@@ -4,10 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
   merge_group:
-  push:
-    branches:
-      - main
-      - develop
 
 jobs:
   install:

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -4,10 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
   merge_group:
-  push:
-    branches:
-      - master
-      - develop
 
 jobs:
   test-unit:


### PR DESCRIPTION
Removing `push` hook in ci config as it does not work nicely with `github.head_ref`. It is also duplicated work since CI is already ran with `pull_request`.