### PR TITLE
ci: use sha instead of head ref to support push and pull

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -151,7 +151,7 @@ jobs:
           l3-node: true
           no-token-bridge: true
           no-l3-token-bridge: true
-          nitro-contracts-branch: '${{ github.sha }}'
+          nitro-contracts-branch: '${{ github.event.pull_request.head.sha || github.sha }}'
           nitro-testnode-ref: node-18
 
       - name: Setup node/yarn
@@ -183,7 +183,7 @@ jobs:
           args: --l3-fee-token
           no-token-bridge: true
           no-l3-token-bridge: true
-          nitro-contracts-branch: '${{ github.sha }}'
+          nitro-contracts-branch: '${{ github.event.pull_request.head.sha || github.sha }}'
           nitro-testnode-ref: node-18
 
       - name: Setup node/yarn
@@ -215,7 +215,7 @@ jobs:
           args: --l3-fee-token --l3-fee-token-decimals 6
           no-token-bridge: true
           no-l3-token-bridge: true
-          nitro-contracts-branch: '${{ github.sha }}'
+          nitro-contracts-branch: '${{ github.event.pull_request.head.sha || github.sha }}'
           nitro-testnode-ref: 'non18-decimal-token-node-18'
 
       - name: Setup node/yarn

--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -151,7 +151,7 @@ jobs:
           l3-node: true
           no-token-bridge: true
           no-l3-token-bridge: true
-          nitro-contracts-branch: '${{ github.head_ref }}'
+          nitro-contracts-branch: '${{ github.sha }}'
           nitro-testnode-ref: node-18
 
       - name: Setup node/yarn
@@ -183,7 +183,7 @@ jobs:
           args: --l3-fee-token
           no-token-bridge: true
           no-l3-token-bridge: true
-          nitro-contracts-branch: '${{ github.head_ref }}'
+          nitro-contracts-branch: '${{ github.sha }}'
           nitro-testnode-ref: node-18
 
       - name: Setup node/yarn
@@ -215,7 +215,7 @@ jobs:
           args: --l3-fee-token --l3-fee-token-decimals 6
           no-token-bridge: true
           no-l3-token-bridge: true
-          nitro-contracts-branch: '${{ github.head_ref }}'
+          nitro-contracts-branch: '${{ github.sha }}'
           nitro-testnode-ref: 'non18-decimal-token-node-18'
 
       - name: Setup node/yarn


### PR DESCRIPTION
Using solution from https://github.com/orgs/community/discussions/26325#discussioncomment-5397362

Testing push hook here: https://github.com/OffchainLabs/nitro-contracts/commit/8bec0e5fbd70c7006e41ef7df0765f20f2520d33