### PR TITLE
chore: pin pragma

### DIFF
--- a/src/bridge/AbsBridge.sol
+++ b/src/bridge/AbsBridge.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";

--- a/src/bridge/AbsInbox.sol
+++ b/src/bridge/AbsInbox.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 import {
     DataTooLarge,

--- a/src/bridge/AbsOutbox.sol
+++ b/src/bridge/AbsOutbox.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 import {
     AlreadyInit,

--- a/src/bridge/Bridge.sol
+++ b/src/bridge/Bridge.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";

--- a/src/bridge/ERC20Bridge.sol
+++ b/src/bridge/ERC20Bridge.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 import "./AbsBridge.sol";
 import "./IERC20Bridge.sol";

--- a/src/bridge/ERC20Inbox.sol
+++ b/src/bridge/ERC20Inbox.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 import "./AbsInbox.sol";
 import "./IERC20Inbox.sol";

--- a/src/bridge/ERC20Outbox.sol
+++ b/src/bridge/ERC20Outbox.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 import "./AbsOutbox.sol";
 import {IERC20Bridge} from "./IERC20Bridge.sol";

--- a/src/bridge/GasRefunder.sol
+++ b/src/bridge/GasRefunder.sol
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-pragma solidity ^0.8.7;
+pragma solidity 0.8.9;
 
 import "../libraries/IGasRefunder.sol";
 

--- a/src/bridge/Inbox.sol
+++ b/src/bridge/Inbox.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 import {
     NotOrigin,

--- a/src/bridge/Messages.sol
+++ b/src/bridge/Messages.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 library Messages {
     function messageHash(

--- a/src/bridge/Outbox.sol
+++ b/src/bridge/Outbox.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 import "./AbsOutbox.sol";
 

--- a/src/bridge/SequencerInbox.sol
+++ b/src/bridge/SequencerInbox.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import {
     AlreadyInit,

--- a/src/chain/CacheManager.sol
+++ b/src/chain/CacheManager.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../precompiles/ArbOwnerPublic.sol";
 import "../precompiles/ArbWasm.sol";

--- a/src/challenge/ChallengeLib.sol
+++ b/src/challenge/ChallengeLib.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../state/Machine.sol";
 import "../state/GlobalState.sol";

--- a/src/challenge/ChallengeManager.sol
+++ b/src/challenge/ChallengeManager.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../libraries/DelegateCallAware.sol";
 import "../osp/IOneStepProofEntry.sol";

--- a/src/challenge/IChallengeManager.sol
+++ b/src/challenge/IChallengeManager.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../state/Machine.sol";
 import "../bridge/IBridge.sol";

--- a/src/challenge/IChallengeResultReceiver.sol
+++ b/src/challenge/IChallengeResultReceiver.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 interface IChallengeResultReceiver {
     function completeChallenge(

--- a/src/libraries/AddressAliasHelper.sol
+++ b/src/libraries/AddressAliasHelper.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 library AddressAliasHelper {
     uint160 internal constant OFFSET = uint160(0x1111000000000000000000000000000000001111);

--- a/src/libraries/AdminFallbackProxy.sol
+++ b/src/libraries/AdminFallbackProxy.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/proxy/Proxy.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";

--- a/src/libraries/ArbitrumChecker.sol
+++ b/src/libraries/ArbitrumChecker.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../precompiles/ArbSys.sol";
 

--- a/src/libraries/Constants.sol
+++ b/src/libraries/Constants.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 uint64 constant NO_CHAL_INDEX = 0;
 

--- a/src/libraries/CryptographyPrimitives.sol
+++ b/src/libraries/CryptographyPrimitives.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 ///      This algorithm has been extracted from the implementation of smart pool (https://github.com/smartpool)
 library CryptographyPrimitives {

--- a/src/libraries/DecimalsConverterHelper.sol
+++ b/src/libraries/DecimalsConverterHelper.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/src/libraries/DelegateCallAware.sol
+++ b/src/libraries/DelegateCallAware.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import {NotOwner} from "./Error.sol";
 

--- a/src/libraries/DoubleLogicUUPSUpgradeable.sol
+++ b/src/libraries/DoubleLogicUUPSUpgradeable.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import {DoubleLogicERC1967Upgrade} from "./AdminFallbackProxy.sol";
 import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";

--- a/src/libraries/Error.sol
+++ b/src/libraries/Error.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 /// @dev Init was already called
 error AlreadyInit();

--- a/src/libraries/GasRefundEnabled.sol
+++ b/src/libraries/GasRefundEnabled.sol
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 // solhint-disable-next-line compiler-version
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./IReader4844.sol";
 import "./IGasRefunder.sol";

--- a/src/libraries/MerkleLib.sol
+++ b/src/libraries/MerkleLib.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 import {MerkleProofTooLong} from "./Error.sol";
 

--- a/src/libraries/MessageTypes.sol
+++ b/src/libraries/MessageTypes.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 uint8 constant L2_MSG = 3;
 uint8 constant L1MessageType_L2FundedByL1 = 7;

--- a/src/libraries/UUPSNotUpgradeable.sol
+++ b/src/libraries/UUPSNotUpgradeable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // OpenZeppelin Contracts (last updated v4.5.0) (proxy/utils/UUPSUpgradeable.sol)
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/interfaces/draft-IERC1822.sol";
 import {DoubleLogicERC1967Upgrade} from "./AdminFallbackProxy.sol";

--- a/src/mocks/HostioTest.sol
+++ b/src/mocks/HostioTest.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.24;
+pragma solidity 0.8.24;
 
 /*
  * HostioTest is a test contract used to compare EVM with Stylus.

--- a/src/osp/HashProofHelper.sol
+++ b/src/osp/HashProofHelper.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../libraries/CryptographyPrimitives.sol";
 

--- a/src/osp/IOneStepProofEntry.sol
+++ b/src/osp/IOneStepProofEntry.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./IOneStepProver.sol";
 

--- a/src/osp/IOneStepProver.sol
+++ b/src/osp/IOneStepProver.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../state/Machine.sol";
 import "../state/Module.sol";

--- a/src/osp/OneStepProofEntry.sol
+++ b/src/osp/OneStepProofEntry.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../state/Deserialize.sol";
 import "../state/Machine.sol";

--- a/src/osp/OneStepProver0.sol
+++ b/src/osp/OneStepProver0.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../state/Value.sol";
 import "../state/Machine.sol";

--- a/src/osp/OneStepProverHostIo.sol
+++ b/src/osp/OneStepProverHostIo.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../state/Value.sol";
 import "../state/Machine.sol";

--- a/src/osp/OneStepProverMath.sol
+++ b/src/osp/OneStepProverMath.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../state/Value.sol";
 import "../state/Machine.sol";

--- a/src/osp/OneStepProverMemory.sol
+++ b/src/osp/OneStepProverMemory.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../state/Value.sol";
 import "../state/Machine.sol";

--- a/src/rollup/AbsRollupEventInbox.sol
+++ b/src/rollup/AbsRollupEventInbox.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./IRollupEventInbox.sol";
 import "../bridge/IBridge.sol";

--- a/src/rollup/BridgeCreator.sol
+++ b/src/rollup/BridgeCreator.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../bridge/Bridge.sol";
 import "../bridge/SequencerInbox.sol";

--- a/src/rollup/Config.sol
+++ b/src/rollup/Config.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../state/GlobalState.sol";
 import "../state/Machine.sol";

--- a/src/rollup/DeployHelper.sol
+++ b/src/rollup/DeployHelper.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import {IInbox} from "../bridge/IInbox.sol";
 import {IInboxBase} from "../bridge/IInboxBase.sol";

--- a/src/rollup/ERC20RollupEventInbox.sol
+++ b/src/rollup/ERC20RollupEventInbox.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./AbsRollupEventInbox.sol";
 import "../bridge/IERC20Bridge.sol";

--- a/src/rollup/FactoryDeployerHelper.sol
+++ b/src/rollup/FactoryDeployerHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 /**
  * @title Helper contract for cross-chain deployment of deterministic factories when rollup uses custom fee token

--- a/src/rollup/IRollupAdmin.sol
+++ b/src/rollup/IRollupAdmin.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./IRollupCore.sol";
 import "../bridge/ISequencerInbox.sol";

--- a/src/rollup/IRollupCore.sol
+++ b/src/rollup/IRollupCore.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./Node.sol";
 import "../bridge/IBridge.sol";

--- a/src/rollup/IRollupEventInbox.sol
+++ b/src/rollup/IRollupEventInbox.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../bridge/IBridge.sol";
 

--- a/src/rollup/IRollupLogic.sol
+++ b/src/rollup/IRollupLogic.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./IRollupCore.sol";
 import "../bridge/ISequencerInbox.sol";

--- a/src/rollup/Node.sol
+++ b/src/rollup/Node.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../state/GlobalState.sol";
 import "../state/Machine.sol";

--- a/src/rollup/RollupAdminLogic.sol
+++ b/src/rollup/RollupAdminLogic.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./IRollupAdmin.sol";
 import "./IRollupLogic.sol";

--- a/src/rollup/RollupCore.sol
+++ b/src/rollup/RollupCore.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 

--- a/src/rollup/RollupCreator.sol
+++ b/src/rollup/RollupCreator.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./RollupProxy.sol";
 import "./IRollupAdmin.sol";

--- a/src/rollup/RollupEventInbox.sol
+++ b/src/rollup/RollupEventInbox.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./AbsRollupEventInbox.sol";
 import "../bridge/IEthBridge.sol";

--- a/src/rollup/RollupLib.sol
+++ b/src/rollup/RollupLib.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../challenge/IChallengeManager.sol";
 import "../challenge/ChallengeLib.sol";

--- a/src/rollup/RollupProxy.sol
+++ b/src/rollup/RollupProxy.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../libraries/AdminFallbackProxy.sol";
 import "./IRollupAdmin.sol";

--- a/src/rollup/RollupUserLogic.sol
+++ b/src/rollup/RollupUserLogic.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 

--- a/src/rollup/ValidatorUtils.sol
+++ b/src/rollup/ValidatorUtils.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 pragma experimental ABIEncoderV2;
 

--- a/src/rollup/ValidatorWallet.sol
+++ b/src/rollup/ValidatorWallet.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../challenge/IChallengeManager.sol";
 import "../libraries/DelegateCallAware.sol";

--- a/src/rollup/ValidatorWalletCreator.sol
+++ b/src/rollup/ValidatorWalletCreator.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";

--- a/src/state/Deserialize.sol
+++ b/src/state/Deserialize.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./Value.sol";
 import "./ValueStack.sol";

--- a/src/state/GlobalState.sol
+++ b/src/state/GlobalState.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 struct GlobalState {
     bytes32[2] bytes32Vals;

--- a/src/state/Instructions.sol
+++ b/src/state/Instructions.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 struct Instruction {
     uint16 opcode;

--- a/src/state/Machine.sol
+++ b/src/state/Machine.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./ValueStack.sol";
 import "./Instructions.sol";

--- a/src/state/MerkleProof.sol
+++ b/src/state/MerkleProof.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./Value.sol";
 import "./Instructions.sol";

--- a/src/state/Module.sol
+++ b/src/state/Module.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./ModuleMemoryCompact.sol";
 

--- a/src/state/ModuleMemory.sol
+++ b/src/state/ModuleMemory.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./MerkleProof.sol";
 import "./Deserialize.sol";

--- a/src/state/ModuleMemoryCompact.sol
+++ b/src/state/ModuleMemoryCompact.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 struct ModuleMemory {
     uint64 size;

--- a/src/state/MultiStack.sol
+++ b/src/state/MultiStack.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 struct MultiStack {
     bytes32 inactiveStackHash; // NO_STACK_HASH if no stack, 0 if empty stack

--- a/src/state/PcArray.sol
+++ b/src/state/PcArray.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 struct PcArray {
     uint32[] inner;

--- a/src/state/StackFrame.sol
+++ b/src/state/StackFrame.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./Value.sol";
 

--- a/src/state/Value.sol
+++ b/src/state/Value.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 enum ValueType {
     I32,

--- a/src/state/ValueArray.sol
+++ b/src/state/ValueArray.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./Value.sol";
 

--- a/src/state/ValueStack.sol
+++ b/src/state/ValueStack.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "./Value.sol";
 import "./ValueArray.sol";

--- a/src/test-helpers/BridgeTester.sol
+++ b/src/test-helpers/BridgeTester.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";

--- a/src/test-helpers/CryptographyPrimitivesTester.sol
+++ b/src/test-helpers/CryptographyPrimitivesTester.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../libraries/CryptographyPrimitives.sol";
 

--- a/src/test-helpers/EthVault.sol
+++ b/src/test-helpers/EthVault.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 /**
  * Simple contract for testing bridge calls which include calldata

--- a/src/test-helpers/MessageTester.sol
+++ b/src/test-helpers/MessageTester.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../bridge/Messages.sol";
 

--- a/src/test-helpers/OutboxWithoutOptTester.sol
+++ b/src/test-helpers/OutboxWithoutOptTester.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 import {
     AlreadyInit,

--- a/src/test-helpers/RollupMock.sol
+++ b/src/test-helpers/RollupMock.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.4;
+pragma solidity 0.8.9;
 
 contract RollupMock {
     event WithdrawTriggered();

--- a/src/test-helpers/TestToken.sol
+++ b/src/test-helpers/TestToken.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/nitro/blob/master/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/src/test-helpers/ValueArrayTester.sol
+++ b/src/test-helpers/ValueArrayTester.sol
@@ -2,7 +2,7 @@
 // For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.9;
 
 import "../state/ValueArray.sol";
 


### PR DESCRIPTION
Pin pragma to the expected version due to https://github.com/OffchainLabs/nitro-contracts/pull/255 removed the default solc in foundry config.