### PR TITLE
fix: express lane testReduce

### DIFF
--- a/test/foundry/ExpressLaneBalance.t.sol
+++ b/test/foundry/ExpressLaneBalance.t.sol
@@ -106,7 +106,7 @@ contract ExpressLaneBalanceTest is Test {
         if (initialRound <= reduceRound) {
             vm.expectRevert(abi.encodeWithSelector(InsufficientBalance.selector, reduceAmount, 0));
             b.reduce(reduceAmount, reduceRound);
-        } else if (reduceAmount > initialBalance) {
+        } else if (reduceAmount > initialBalance || initialBalance == 0) {
             vm.expectRevert(
                 abi.encodeWithSelector(InsufficientBalance.selector, reduceAmount, initialBalance)
             );


### PR DESCRIPTION
Test might fail if `initialBalance==0 and reduceAmount==0` before the fix.