### PR TITLE
chore: effectively disableing delay buffer

### DIFF
--- a/scripts/files/configs/local.ts
+++ b/scripts/files/configs/local.ts
@@ -43,8 +43,8 @@ export const local: Config = {
     maxDataSize: 117964,
     isDelayBufferable: true,
     bufferConfig: {
-      max: 14400,
-      threshold: 300,
+      max: 2 ** 32, // effectively disableing and will be enabled later
+      threshold: 2 ** 32, // 365 days, effectively disableing and will be enabled later
       replenishRateInBasis: 500,
     },
   },

--- a/scripts/files/configs/local.ts
+++ b/scripts/files/configs/local.ts
@@ -44,7 +44,7 @@ export const local: Config = {
     isDelayBufferable: true,
     bufferConfig: {
       max: 2 ** 32, // effectively disableing and will be enabled later
-      threshold: 2 ** 32, // 365 days, effectively disableing and will be enabled later
+      threshold: 2 ** 32, // effectively disableing and will be enabled later
       replenishRateInBasis: 500,
     },
   },

--- a/scripts/files/configs/sepolia.ts
+++ b/scripts/files/configs/sepolia.ts
@@ -36,8 +36,8 @@ export const sepolia: Config = {
     maxDataSize: 117964,
     isDelayBufferable: true,
     bufferConfig: {
-      max: hoursToBlocks(24 * 365), // 365 days, effectively disableing and will be enabled later
-      threshold: hoursToBlocks(24 * 365), // 365 days, effectively disableing and will be enabled later
+      max: 2 ** 32, // effectively disableing and will be enabled later
+      threshold: 2 ** 32, // 365 days, effectively disableing and will be enabled later
       replenishRateInBasis: 500, // 5% replenishment rate
     },
   },

--- a/scripts/files/configs/sepolia.ts
+++ b/scripts/files/configs/sepolia.ts
@@ -37,7 +37,7 @@ export const sepolia: Config = {
     isDelayBufferable: true,
     bufferConfig: {
       max: 2 ** 32, // effectively disableing and will be enabled later
-      threshold: 2 ** 32, // 365 days, effectively disableing and will be enabled later
+      threshold: 2 ** 32, // effectively disableing and will be enabled later
       replenishRateInBasis: 500, // 5% replenishment rate
     },
   },


### PR DESCRIPTION
If `isDelayBufferable` is set to false, it is hard to re-enable without doing contract upgrade due to the flag is stored in an immutable for gas optimization. We temporarily disable delay buffer by using a large threshold value so that `isSynced` return true and will not require a delay proof when posting batches.
```
    function isSynced(
        BufferData storage self
    ) internal view returns (bool) {
        return block.number - self.prevBlockNumber <= self.threshold;
    }
```
the previous config for sepolia is not large enough because `prevBlockNumber` might be 0 after an upgrade