### PR TITLE
ArbOS11To32UpgradeTest

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -65,6 +65,16 @@
     // Server-Side Request Forgery in axios
     "GHSA-8hc4-vh64-cxmj",
     // Regular Expression Denial of Service (ReDoS) in micromatch
-    "GHSA-952p-6rrq-rcjv"
+    "GHSA-952p-6rrq-rcjv",
+    // cookie accepts cookie name, path, and domain with out of bounds characters
+    "GHSA-pxg6-pf52-xh8x",
+    // Elliptic's verify function omits uniqueness validation
+    "GHSA-434g-2637-qmqr",
+    // Valid ECDSA signatures erroneously rejected in Elliptic
+    "GHSA-fc9h-whq2-v747",
+    // secp256k1-node allows private key extraction over ECDH
+    "GHSA-584q-6j8j-r5pm",
+    // Regular Expression Denial of Service (ReDoS) in cross-spawn
+    "GHSA-3xgq-45jj-v275"
   ]
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -44,6 +44,16 @@ const solidity = {
         evmVersion: 'cancun',
       },
     },
+    'src/mocks/ArbOS11To32UpgradeTest.sol': {
+      version: '0.8.24',
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 100,
+        },
+        evmVersion: 'cancun',
+      },
+    },
   },
 }
 
@@ -68,6 +78,16 @@ if (process.env['INTERFACE_TESTER_SOLC_VERSION']) {
       },
     },
     'src/mocks/HostioTest.sol': {
+      version: '0.8.24',
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 100,
+        },
+        evmVersion: 'cancun',
+      },
+    },
+    'src/mocks/ArbOS11To32UpgradeTest.sol': {
       version: '0.8.24',
       settings: {
         optimizer: {

--- a/src/mocks/ArbOS11To32UpgradeTest.sol
+++ b/src/mocks/ArbOS11To32UpgradeTest.sol
@@ -9,9 +9,9 @@ import "../precompiles/ArbSys.sol";
 contract ArbOS11To32UpgradeTest {
     function mcopy() external returns (bytes32 x) {
         assembly {
-            mstore(0x20, 0x9)  // Store 0x9 at word 1 in memory
-            mcopy(0, 0x20, 0x20)  // Copies 0x9 to word 0 in memory
-            x := mload(0)    // Returns 32 bytes "0x9"
+            mstore(0x20, 0x9) // Store 0x9 at word 1 in memory
+            mcopy(0, 0x20, 0x20) // Copies 0x9 to word 0 in memory
+            x := mload(0) // Returns 32 bytes "0x9"
         }
         require(ArbSys(address(0x64)).arbOSVersion() == 55 + 32, "EXPECTED_ARBOS_32");
     }

--- a/src/mocks/ArbOS11To32UpgradeTest.sol
+++ b/src/mocks/ArbOS11To32UpgradeTest.sol
@@ -1,0 +1,13 @@
+// Copyright 2024, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.24;
+
+import "../precompiles/ArbSys.sol";
+
+contract ArbOS11To32UpgradeTest {
+    function mcopy() external view {
+        require(ArbSys(address(0x64)).arbOSVersion() == 55 + 32, "EXPECTED_ARBOS_32");
+    }
+}

--- a/src/mocks/ArbOS11To32UpgradeTest.sol
+++ b/src/mocks/ArbOS11To32UpgradeTest.sol
@@ -7,7 +7,12 @@ pragma solidity ^0.8.24;
 import "../precompiles/ArbSys.sol";
 
 contract ArbOS11To32UpgradeTest {
-    function mcopy() external view {
+    function mcopy() external returns (bytes32 x) {
+        assembly {
+            mstore(0x20, 0x9)  // Store 0x9 at word 1 in memory
+            mcopy(0, 0x20, 0x20)  // Copies 0x9 to word 0 in memory
+            x := mload(0)    // Returns 32 bytes "0x9"
+        }
         require(ArbSys(address(0x64)).arbOSVersion() == 55 + 32, "EXPECTED_ARBOS_32");
     }
 }


### PR DESCRIPTION
Resolves NIT-2975

Adds a test contract that has a function that uses mcopy, an instruction that is supported in ArbOS 32 but not in ArbOS 11.
It also updates audit-ci.jsonc, with changes that are already in the develop branch.

To be used in https://github.com/OffchainLabs/nitro/pull/2837

Attention to the base branch.
Current version of develop is not compatible with nitro, so a `pre-bold` branch, checked out from main, was created to support changes that should be introduced to nitro while bold is not fully integrated to it.