### PR TITLE
ArbOS11To32UpgradeTest

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -53,6 +53,16 @@ const solidity = {
         evmVersion: 'cancun',
       },
     },
+    'src/mocks/ArbOS11To32UpgradeTest.sol': {
+      version: '0.8.24',
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 100,
+        },
+        evmVersion: 'cancun',
+      },
+    },
   },
 }
 
@@ -80,6 +90,16 @@ if (process.env['INTERFACE_TESTER_SOLC_VERSION']) {
       },
     },
     'src/mocks/HostioTest.sol': {
+      version: '0.8.24',
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 100,
+        },
+        evmVersion: 'cancun',
+      },
+    },
+    'src/mocks/ArbOS11To32UpgradeTest.sol': {
       version: '0.8.24',
       settings: {
         optimizer: {

--- a/src/mocks/ArbOS11To32UpgradeTest.sol
+++ b/src/mocks/ArbOS11To32UpgradeTest.sol
@@ -9,9 +9,9 @@ import "../precompiles/ArbSys.sol";
 contract ArbOS11To32UpgradeTest {
     function mcopy() external returns (bytes32 x) {
         assembly {
-            mstore(0x20, 0x9)  // Store 0x9 at word 1 in memory
-            mcopy(0, 0x20, 0x20)  // Copies 0x9 to word 0 in memory
-            x := mload(0)    // Returns 32 bytes "0x9"
+            mstore(0x20, 0x9) // Store 0x9 at word 1 in memory
+            mcopy(0, 0x20, 0x20) // Copies 0x9 to word 0 in memory
+            x := mload(0) // Returns 32 bytes "0x9"
         }
         require(ArbSys(address(0x64)).arbOSVersion() == 55 + 32, "EXPECTED_ARBOS_32");
     }

--- a/src/mocks/ArbOS11To32UpgradeTest.sol
+++ b/src/mocks/ArbOS11To32UpgradeTest.sol
@@ -1,0 +1,18 @@
+// Copyright 2024, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.24;
+
+import "../precompiles/ArbSys.sol";
+
+contract ArbOS11To32UpgradeTest {
+    function mcopy() external returns (bytes32 x) {
+        assembly {
+            mstore(0x20, 0x9)  // Store 0x9 at word 1 in memory
+            mcopy(0, 0x20, 0x20)  // Copies 0x9 to word 0 in memory
+            x := mload(0)    // Returns 32 bytes "0x9"
+        }
+        require(ArbSys(address(0x64)).arbOSVersion() == 55 + 32, "EXPECTED_ARBOS_32");
+    }
+}


### PR DESCRIPTION
Resolves NIT-2975

Adds a test contract that has a function that uses mcopy, an instruction that is supported in ArbOS 32 but not in ArbOS 11.

To be used in https://github.com/OffchainLabs/nitro/pull/2837