### PR TITLE
Add a BigMap contract for testing the storage trie

### DIFF
--- a/src/mocks/BigMap.sol
+++ b/src/mocks/BigMap.sol
@@ -1,0 +1,23 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For license information, see:
+// https://github.com/OffchainLabs/nitro/blob/master/LICENSE.md
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+contract BigMap {
+    mapping(uint256 => uint256) public data;
+    uint256 size;
+
+    function clearAndAddValues(uint256 clear, uint256 add) external {
+        uint256 i = size;
+        while (i < size + add) {
+            data[i] = 8675309;
+            i++;
+        }
+        size = i;
+        for (uint256 j = 0; j < clear; j++) {
+            data[j] = 0;
+        }
+    }
+}


### PR DESCRIPTION
This contracts makes it easy to add a bunch of storage slots in a single transation, and then in a separate transaction to free a bunch of those slots and add some others.

The idea is that this sort of operation will pass with the deterministic flag on the storage db implementation set and fail when it is not set.

Part of NIT-3068