### PR TITLE
Add setWasmMaxSize to ArbOwner in v2-main

### DIFF
--- a/src/precompiles/ArbOwner.sol
+++ b/src/precompiles/ArbOwner.sol
@@ -108,6 +108,9 @@ interface ArbOwner {
     /// @notice Sets the maximum number of pages a wasm may allocate
     function setWasmPageLimit(uint16 limit) external;
 
+    /// @notice Sets the maximum size of the uncompressed wasm code in bytes
+    function setWasmMaxSize(uint32 size) external;
+
     /// @notice Sets the minimum costs to invoke a program
     /// @param gas amount of gas paid in increments of 256 when not the program is not cached
     /// @param cached amount of gas paid in increments of 64 when the program is cached


### PR DESCRIPTION
This was already reviewed for the `develop` branch, and the `yarn format` command was used to format it consistently with the rules on this branch.