### PR TITLE
feat: always send batch posting report

### DIFF
--- a/src/bridge/ISequencerInbox.sol
+++ b/src/bridge/ISequencerInbox.sol
@@ -69,6 +69,9 @@ interface ISequencerInbox is IDelayedMessageProvider {
     /// @dev Owner set the buffer config.
     event BufferConfigSet(BufferConfig bufferConfig);
 
+    /// @dev Owner set the fee token pricer.
+    event FeeTokenPricerSet(address feeTokenPricer);
+
     function totalDelayedMessagesRead() external view returns (uint256);
 
     function bridge() external view returns (IBridge);

--- a/src/bridge/SequencerInbox.sol
+++ b/src/bridge/SequencerInbox.sol
@@ -880,6 +880,7 @@ contract SequencerInbox is DelegateCallAware, GasRefundEnabled, ISequencerInbox 
         }
 
         feeTokenPricer = feeTokenPricer_;
+        emit FeeTokenPricerSet(address(feeTokenPricer_));
         emit OwnerFunctionCalled(6);
     }
 


### PR DESCRIPTION
In v3.0.0 and earlier versions, custom fee token chains do not send batch posting reports at all so that data fee would not be charged on the child chain. With this purposed change, we will change the behavior such that batch posting reports are always sent. This would require legacy chains to make some call to ArbOwner (e.g. setPerBatchGasCharge(0)) to preserve the legacy behaviors.