### PR TITLE
Add MintNativeToken and BurnNativeToken calls

### DIFF
--- a/src/precompiles/ArbOwner.sol
+++ b/src/precompiles/ArbOwner.sol
@@ -211,13 +211,13 @@ interface ArbOwner {
      * @notice Mints some amount of the native gas token for this chain to the
      * given address.
      */
-    function mintNativeToken(address to, uint64 amount) external;
+    function mintNativeToken(address to, uint256 amount) external;
 
     /**
      * @notice Burns some amount of the native gas token for this chain from the
      * given address.
      */
-    function burnNativeToken(address from, uint64 amount) external;
+    function burnNativeToken(address from, uint256 amount) external;
 
     /**
      * @notice Sets the increased calldata price feature on or off (EIP-7623)

--- a/src/precompiles/ArbOwner.sol
+++ b/src/precompiles/ArbOwner.sol
@@ -208,6 +208,18 @@ interface ArbOwner {
     ) external;
 
     /**
+     * @notice Mints some amount of the native gas token for this chain to the
+     * given address.
+     */
+    function mintNativeToken(address to, uint64 amount) external;
+
+    /**
+     * @notice Burns some amount of the native gas token for this chain from the
+     * given address.
+     */
+    function burnNativeToken(address from, uint64 amount) external;
+
+    /**
      * @notice Sets the increased calldata price feature on or off (EIP-7623)
      * Available in ArbOS version 40 with default as false
      */


### PR DESCRIPTION
These will allow arbOwner authorized addresses to mint some amount of the chain's native gas token to or burn some amount of the chain's native gas token from a given address.

Chain owners *should* deploy a non-upgradable intermediary contract, the address of which is added to the set of arbOwner addresses and then add any addresses which should be allowed to mint and burn the native gas token to call corresponding methods on the proxy contract. The implementation of those intermediary contract methods should not allow to and from address arguments, and instead use the address of the caller as the target for minting and burning.

Resolves: NIT-3297