### PR TITLE
Mint-Burn gas token privileged contract

### DIFF
--- a/src/bridge/IMinterBurnerForwarder.sol
+++ b/src/bridge/IMinterBurnerForwarder.sol
@@ -1,0 +1,27 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+interface IMinterBurnerForwarder {
+    /**
+     * @notice Mints some amount of the native gas token for this chain to the calling address.
+     * @dev This function calls mintNativeToken in the ArbOwner precompile, so this contract must also be a chain owner.
+     *      No events are emitted in this function, since the ArbOwner precompile already emits OwnerActs()
+     * @param amount The amount of native gas token to mint
+     */
+    function mintNativeToken(
+        uint256 amount
+    ) external;
+
+    /**
+     * @notice Burns some amount of the native gas token for this chain from the given address.
+     * @dev This function calls burnNativeToken in the ArbOwner precompile, so this contract must also be a chain owner.
+     *      No events are emitted in this function, since the ArbOwner precompile already emits OwnerActs()
+     * @param amount The amount of native gas token to burn
+     */
+    function burnNativeToken(
+        uint256 amount
+    ) external;
+}

--- a/src/bridge/IMinterBurnerForwarder.sol
+++ b/src/bridge/IMinterBurnerForwarder.sol
@@ -9,19 +9,23 @@ interface IMinterBurnerForwarder {
      * @notice Mints some amount of the native gas token for this chain to the calling address.
      * @dev This function calls mintNativeToken in the ArbOwner precompile, so this contract must also be a chain owner.
      *      No events are emitted in this function, since the ArbOwner precompile already emits OwnerActs()
+     * @param to The address credited with the minted native gas token
      * @param amount The amount of native gas token to mint
      */
-    function mintNativeToken(
-        uint256 amount
-    ) external;
+    function mintNativeToken(address to, uint256 amount) external;
 
     /**
      * @notice Burns some amount of the native gas token for this chain from the given address.
      * @dev This function calls burnNativeToken in the ArbOwner precompile, so this contract must also be a chain owner.
      *      No events are emitted in this function, since the ArbOwner precompile already emits OwnerActs()
+     * @param from The address to burn the native gas token from
      * @param amount The amount of native gas token to burn
      */
-    function burnNativeToken(
-        uint256 amount
-    ) external;
+    function burnNativeToken(address from, uint256 amount) external;
+
+    /// @notice The role given to the addresses that can mint native gas token
+    function MINTER_ROLE() external returns (bytes32);
+
+    /// @notice The role given to the addresses that can burn native gas token
+    function BURNER_ROLE() external returns (bytes32);
 }

--- a/src/bridge/MinterBurnerForwarder.sol
+++ b/src/bridge/MinterBurnerForwarder.sol
@@ -16,8 +16,8 @@ import "../precompiles/ArbOwner.sol";
  */
 contract MinterBurnerForwarder is IMinterBurnerForwarder, AccessControlEnumerable {
     // Roles
-    bytes32 public constant MINTER_ROLE = keccak256("MINTER");
-    bytes32 public constant BURNER_ROLE = keccak256("BURNER");
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
 
     // ArbOwner precompile
     ArbOwner constant ARB_OWNER = ArbOwner(address(112));
@@ -40,16 +40,12 @@ contract MinterBurnerForwarder is IMinterBurnerForwarder, AccessControlEnumerabl
     }
 
     /// @inheritdoc IMinterBurnerForwarder
-    function mintNativeToken(
-        uint256 amount
-    ) external onlyRole(MINTER_ROLE) {
-        ARB_OWNER.mintNativeToken(msg.sender, amount);
+    function mintNativeToken(address to, uint256 amount) external onlyRole(MINTER_ROLE) {
+        ARB_OWNER.mintNativeToken(to, amount);
     }
 
     /// @inheritdoc IMinterBurnerForwarder
-    function burnNativeToken(
-        uint256 amount
-    ) external onlyRole(BURNER_ROLE) {
-        ARB_OWNER.burnNativeToken(msg.sender, amount);
+    function burnNativeToken(address from, uint256 amount) external onlyRole(BURNER_ROLE) {
+        ARB_OWNER.burnNativeToken(from, amount);
     }
 }

--- a/src/bridge/MinterBurnerForwarder.sol
+++ b/src/bridge/MinterBurnerForwarder.sol
@@ -22,21 +22,33 @@ contract MinterBurnerForwarder is IMinterBurnerForwarder, AccessControlEnumerabl
     // ArbOwner precompile
     ArbOwner constant ARB_OWNER = ArbOwner(address(112));
 
-    constructor(address[] memory admins, address[] memory minters, address[] memory burners) {
-        // Grant ADMIN role to admins
-        for (uint256 i = 0; i < admins.length; i++) {
-            _grantRole(DEFAULT_ADMIN_ROLE, admins[i]);
-        }
-
-        // Grant MINTER role to minters
+    /// @param minters Addresses to grant the MINTER_ROLE
+    /// @param burners Addresses to grant the BURNER_ROLE
+    constructor(address[] memory minters, address[] memory burners) {
+        // Grant MINTER_ROLE role to minters
         for (uint256 i = 0; i < minters.length; i++) {
             _grantRole(MINTER_ROLE, minters[i]);
         }
 
-        // Grant BURNER role to burners
+        // Grant BURNER_ROLE role to burners
         for (uint256 i = 0; i < burners.length; i++) {
             _grantRole(BURNER_ROLE, burners[i]);
         }
+    }
+
+    /**
+     * @dev Returns `true` if:
+     *      - we are checking for the admin role, and `account` is a chain owner
+     *      - we are checking for a different role and `account` has been granted `role`.
+     */
+    function hasRole(
+        bytes32 role,
+        address account
+    ) public view override(AccessControl, IAccessControl) returns (bool) {
+        if (role == DEFAULT_ADMIN_ROLE) {
+            return ARB_OWNER.isChainOwner(account);
+        }
+        return super.hasRole(role, account);
     }
 
     /// @inheritdoc IMinterBurnerForwarder

--- a/src/bridge/MinterBurnerForwarder.sol
+++ b/src/bridge/MinterBurnerForwarder.sol
@@ -1,0 +1,60 @@
+// Copyright 2021-2022, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts/access/AccessControl.sol';
+import '../precompiles/ArbOwner.sol';
+
+/**
+ * @title MinterBurnerForwarder
+ * @notice  This contract allows the chain owner of a chain to give rights for minting and burning native gas tokens to third parties.
+ *          Minting and burning will be done by using the ArbOwner functions mintNativeToken and burnNativeToken.
+ *          This contract must be set as a chain owner of the chain to be able to call ArbOwner functions
+ */
+contract MinterBurnerForwarder is AccessControl {
+    // Roles
+    bytes32 public constant MINTER_ROLE = keccak256('MINTER');
+    bytes32 public constant BURNER_ROLE = keccak256('BURNER');
+
+    // ArbOwner precompile
+    ArbOwner constant ARB_OWNER = ArbOwner(address(112));
+
+    // Events
+    event NativeTokenMinted(address indexed caller, uint256 amount);
+    event NativeTokenBurned(address indexed caller, uint256 amount);
+
+    // Errors
+    error NotChainOwner();
+
+    constructor() {
+        // Check if the deployer is a chain owner
+        if (!ARB_OWNER.isChainOwner(msg.sender)) {
+            revert NotChainOwner();
+        }
+
+        // Grant admin role to the chain owner
+        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    }
+
+    /**
+     * @notice Mints some amount of the native gas token for this chain to the calling address.
+     * @dev This function calls mintNativeToken in the ArbOwner precompile, so this contract must also be a chain owner.
+     * @param amount The amount of native gas token to mint
+     */
+    function mintNativeToken(uint256 amount) external onlyRole(MINTER_ROLE) {
+        ARB_OWNER.mintNativeToken(msg.sender, amount);
+        emit NativeTokenMinted(msg.sender, amount);
+    }
+
+    /**
+     * @notice Burns some amount of the native gas token for this chain from the given address.
+     * @dev This function calls burnNativeToken in the ArbOwner precompile, so this contract must also be a chain owner.
+     * @param amount The amount of native gas token to burn
+     */
+    function burnNativeToken(uint256 amount) external onlyRole(BURNER_ROLE) {
+        ARB_OWNER.burnNativeToken(msg.sender, amount);
+        emit NativeTokenBurned(msg.sender, amount);
+    }
+}

--- a/src/bridge/MinterBurnerForwarder.sol
+++ b/src/bridge/MinterBurnerForwarder.sol
@@ -4,7 +4,7 @@
 
 pragma solidity ^0.8.0;
 
-import '@openzeppelin/contracts/access/AccessControl.sol';
+import '@openzeppelin/contracts/access/AccessControlEnumerable.sol';
 import '../precompiles/ArbOwner.sol';
 
 /**
@@ -13,7 +13,7 @@ import '../precompiles/ArbOwner.sol';
  *          Minting and burning will be done by using the ArbOwner functions mintNativeToken and burnNativeToken.
  *          This contract must be set as a chain owner of the chain to be able to call ArbOwner functions
  */
-contract MinterBurnerForwarder is AccessControl {
+contract MinterBurnerForwarder is AccessControlEnumerable {
     // Roles
     bytes32 public constant MINTER_ROLE = keccak256('MINTER');
     bytes32 public constant BURNER_ROLE = keccak256('BURNER');
@@ -21,40 +21,40 @@ contract MinterBurnerForwarder is AccessControl {
     // ArbOwner precompile
     ArbOwner constant ARB_OWNER = ArbOwner(address(112));
 
-    // Events
-    event NativeTokenMinted(address indexed caller, uint256 amount);
-    event NativeTokenBurned(address indexed caller, uint256 amount);
-
-    // Errors
-    error NotChainOwner();
-
-    constructor() {
-        // Check if the deployer is a chain owner
-        if (!ARB_OWNER.isChainOwner(msg.sender)) {
-            revert NotChainOwner();
+    constructor(address[] memory admins, address[] memory minters, address[] memory burners) {
+        // Grant ADMIN role to admins
+        for (uint256 i = 0; i < admins.length; i++) {
+            _grantRole(DEFAULT_ADMIN_ROLE, admins[i]);
+        }
+        
+        // Grant MINTER role to minters
+        for (uint256 i = 0; i < minters.length; i++) {
+            _grantRole(MINTER_ROLE, minters[i]);
         }
 
-        // Grant admin role to the chain owner
-        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        // Grant BURNER role to burners
+        for (uint256 i = 0; i < burners.length; i++) {
+            _grantRole(BURNER_ROLE, burners[i]);
+        }
     }
 
     /**
      * @notice Mints some amount of the native gas token for this chain to the calling address.
      * @dev This function calls mintNativeToken in the ArbOwner precompile, so this contract must also be a chain owner.
+     *      No events are emitted in this function, since the ArbOwner precompile already emits OwnerActs()
      * @param amount The amount of native gas token to mint
      */
     function mintNativeToken(uint256 amount) external onlyRole(MINTER_ROLE) {
         ARB_OWNER.mintNativeToken(msg.sender, amount);
-        emit NativeTokenMinted(msg.sender, amount);
     }
 
     /**
      * @notice Burns some amount of the native gas token for this chain from the given address.
      * @dev This function calls burnNativeToken in the ArbOwner precompile, so this contract must also be a chain owner.
+     *      No events are emitted in this function, since the ArbOwner precompile already emits OwnerActs()
      * @param amount The amount of native gas token to burn
      */
     function burnNativeToken(uint256 amount) external onlyRole(BURNER_ROLE) {
         ARB_OWNER.burnNativeToken(msg.sender, amount);
-        emit NativeTokenBurned(msg.sender, amount);
     }
 }

--- a/src/bridge/MinterBurnerForwarder.sol
+++ b/src/bridge/MinterBurnerForwarder.sol
@@ -5,6 +5,7 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
+import "./IMinterBurnerForwarder.sol";
 import "../precompiles/ArbOwner.sol";
 
 /**
@@ -13,7 +14,7 @@ import "../precompiles/ArbOwner.sol";
  *          Minting and burning will be done by using the ArbOwner functions mintNativeToken and burnNativeToken.
  *          This contract must be set as a chain owner of the chain to be able to call ArbOwner functions
  */
-contract MinterBurnerForwarder is AccessControlEnumerable {
+contract MinterBurnerForwarder is IMinterBurnerForwarder, AccessControlEnumerable {
     // Roles
     bytes32 public constant MINTER_ROLE = keccak256("MINTER");
     bytes32 public constant BURNER_ROLE = keccak256("BURNER");
@@ -38,24 +39,14 @@ contract MinterBurnerForwarder is AccessControlEnumerable {
         }
     }
 
-    /**
-     * @notice Mints some amount of the native gas token for this chain to the calling address.
-     * @dev This function calls mintNativeToken in the ArbOwner precompile, so this contract must also be a chain owner.
-     *      No events are emitted in this function, since the ArbOwner precompile already emits OwnerActs()
-     * @param amount The amount of native gas token to mint
-     */
+    /// @inheritdoc IMinterBurnerForwarder
     function mintNativeToken(
         uint256 amount
     ) external onlyRole(MINTER_ROLE) {
         ARB_OWNER.mintNativeToken(msg.sender, amount);
     }
 
-    /**
-     * @notice Burns some amount of the native gas token for this chain from the given address.
-     * @dev This function calls burnNativeToken in the ArbOwner precompile, so this contract must also be a chain owner.
-     *      No events are emitted in this function, since the ArbOwner precompile already emits OwnerActs()
-     * @param amount The amount of native gas token to burn
-     */
+    /// @inheritdoc IMinterBurnerForwarder
     function burnNativeToken(
         uint256 amount
     ) external onlyRole(BURNER_ROLE) {

--- a/src/bridge/MinterBurnerForwarder.sol
+++ b/src/bridge/MinterBurnerForwarder.sol
@@ -4,8 +4,8 @@
 
 pragma solidity ^0.8.0;
 
-import '@openzeppelin/contracts/access/AccessControlEnumerable.sol';
-import '../precompiles/ArbOwner.sol';
+import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
+import "../precompiles/ArbOwner.sol";
 
 /**
  * @title MinterBurnerForwarder
@@ -15,8 +15,8 @@ import '../precompiles/ArbOwner.sol';
  */
 contract MinterBurnerForwarder is AccessControlEnumerable {
     // Roles
-    bytes32 public constant MINTER_ROLE = keccak256('MINTER');
-    bytes32 public constant BURNER_ROLE = keccak256('BURNER');
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER");
+    bytes32 public constant BURNER_ROLE = keccak256("BURNER");
 
     // ArbOwner precompile
     ArbOwner constant ARB_OWNER = ArbOwner(address(112));
@@ -26,7 +26,7 @@ contract MinterBurnerForwarder is AccessControlEnumerable {
         for (uint256 i = 0; i < admins.length; i++) {
             _grantRole(DEFAULT_ADMIN_ROLE, admins[i]);
         }
-        
+
         // Grant MINTER role to minters
         for (uint256 i = 0; i < minters.length; i++) {
             _grantRole(MINTER_ROLE, minters[i]);
@@ -44,7 +44,9 @@ contract MinterBurnerForwarder is AccessControlEnumerable {
      *      No events are emitted in this function, since the ArbOwner precompile already emits OwnerActs()
      * @param amount The amount of native gas token to mint
      */
-    function mintNativeToken(uint256 amount) external onlyRole(MINTER_ROLE) {
+    function mintNativeToken(
+        uint256 amount
+    ) external onlyRole(MINTER_ROLE) {
         ARB_OWNER.mintNativeToken(msg.sender, amount);
     }
 
@@ -54,7 +56,9 @@ contract MinterBurnerForwarder is AccessControlEnumerable {
      *      No events are emitted in this function, since the ArbOwner precompile already emits OwnerActs()
      * @param amount The amount of native gas token to burn
      */
-    function burnNativeToken(uint256 amount) external onlyRole(BURNER_ROLE) {
+    function burnNativeToken(
+        uint256 amount
+    ) external onlyRole(BURNER_ROLE) {
         ARB_OWNER.burnNativeToken(msg.sender, amount);
     }
 }


### PR DESCRIPTION
This PR adds a contract that will serve as a proxy for certain privileged accounts to call the new `mintNativeToken` and `burnNativeToken` functions of the ArbOwner precompile.

This privileged accounts will be managed by the chain owner, who must be the deployer of this contract.

This contract must be set as a chain owner of the chain to be able to call ArbOwner functions

Closes BLK-331