### PR TITLE
Native token management rename

### DIFF
--- a/src/precompiles/ArbOwner.sol
+++ b/src/precompiles/ArbOwner.sol
@@ -33,9 +33,9 @@ interface ArbOwner {
     /// @notice Retrieves the list of chain owners
     function getAllChainOwners() external view returns (address[] memory);
 
-    /// @notice Sets the NativeTokenEnabledFrom time
+    /// @notice Sets the NativeTokenManagementFrom time
     /// Available in ArbOS version 41
-    function setNativeTokenEnabledFrom(
+    function setNativeTokenManagementFrom(
         uint64 timestamp
     ) external;
 


### PR DESCRIPTION
fixes: NIT-3389

This names describes the true function - enabling management of native token (add minters) and not enabling the native token itself

pulled by: https://github.com/OffchainLabs/nitro/pull/3264
