### PR TITLE
fix: add zero address check for bridge parameter in ERC20MigrationOutbox constructor

### DIFF
--- a/src/bridge/extra/ERC20MigrationOutbox.sol
+++ b/src/bridge/extra/ERC20MigrationOutbox.sol
@@ -21,6 +21,9 @@ contract ERC20MigrationOutbox is IERC20MigrationOutbox {
     address public immutable destination;
 
     constructor(IERC20Bridge _bridge, address _destination) {
+        if (address(_bridge) == address(0)) {
+            revert InvalidDestination();
+        }
         if (_destination == address(0)) {
             revert InvalidDestination();
         }


### PR DESCRIPTION
Add missing zero address validation for _bridge parameter in ERC20MigrationOutbox constructor to prevent potential runtime errors when bridge.nativeToken() is called with a null bridge reference. This follows the existing pattern of zero address checks in the codebase and uses the established InvalidDestination error.