### PR TITLE
feat: add rpc polling interval to deployment script

### DIFF
--- a/scripts/deployment.ts
+++ b/scripts/deployment.ts
@@ -17,6 +17,10 @@ async function main() {
     signer = signers[0]
   }
 
+  if (process.env.POLLING_INTERVAL !== undefined) {
+    signer.provider.pollingInterval = Number(process.env.POLLING_INTERVAL)
+  }
+
   const maxDataSize =
     process.env.MAX_DATA_SIZE !== undefined
       ? Number(process.env.MAX_DATA_SIZE)

--- a/scripts/deploymentUtils.ts
+++ b/scripts/deploymentUtils.ts
@@ -185,7 +185,7 @@ export async function create2(
     data: concat([salt, data]),
     ...overrides,
   })
-  await tx.wait(2)
+  await tx.wait(Number(process.env.CREATE2_CONFIRMATIONS ?? 2))
 
   return fac.attach(address)
 }


### PR DESCRIPTION
This PR adds a POLLING_INTERVAL env var that can be used to configure ethers polling interval (defaults to 4s) in the deployment script.