### PR TITLE
fix(RollupCreator): refund only the caller's own ETH, not the full contract balance

### DIFF
--- a/src/rollup/RollupCreator.sol
+++ b/src/rollup/RollupCreator.sol
@@ -314,6 +314,11 @@ contract RollupCreator is Ownable {
         uint256 _maxFeePerGas
     ) internal {
         if (_nativeToken == address(0)) {
+            // ETH already held before this call is not part of this deployment and
+            // must not be refunded to the caller. msg.value is what was sent for THIS
+            // createRollup; anything above it is pre-existing and left untouched.
+            uint256 preExistingBalance = address(this).balance - msg.value;
+
             // we need to fund 4 retryable tickets
             uint256 cost =
                 l2FactoriesDeployer.getDeploymentTotalCost(IInboxBase(_inbox), _maxFeePerGas);
@@ -323,7 +328,7 @@ contract RollupCreator is Ownable {
 
             // refund the caller
             // solhint-disable-next-line avoid-low-level-calls
-            (bool sent,) = msg.sender.call{value: address(this).balance}("");
+            (bool sent,) = msg.sender.call{value: address(this).balance - preExistingBalance}("");
             require(sent, "Refund failed");
         } else {
             // Transfer fee token amount needed to pay for retryable fees to the inbox.

--- a/test/foundry/RollupCreator.t.sol
+++ b/test/foundry/RollupCreator.t.sol
@@ -579,6 +579,54 @@ contract RollupCreatorTest is Test {
             bytes32(uint256(keccak256("eip1967.proxy.implementation.secondary")) - 1);
         return address(uint160(uint256(vm.load(proxy, secondarySlot))));
     }
+
+    /// @notice Pre-existing ETH in the creator must not be swept to the caller's refund.
+    function test_createRollup_refundExcludesPreExistingBalance() public {
+        // Simulate ETH already sitting in the creator before this deployment
+        // (a stray transfer, dust, or leftover from a prior interaction).
+        uint256 stray = 0.5 ether;
+        vm.deal(address(rollupCreator), stray);
+
+        vm.startPrank(deployer);
+
+        Config memory config = _getDefaultConfig();
+
+        uint256 factoryDeploymentFunds = 1 ether;
+        vm.deal(deployer, factoryDeploymentFunds);
+
+        address[] memory batchPosters = new address[](1);
+        batchPosters[0] = makeAddr("batch poster 1");
+        address batchPosterManager = makeAddr("batch poster manager");
+        address[] memory validators = new address[](2);
+        validators[0] = makeAddr("validator1");
+        validators[1] = makeAddr("validator2");
+
+        RollupCreator.RollupDeploymentParams memory deployParams = RollupCreator
+            .RollupDeploymentParams({
+            config: config,
+            batchPosters: batchPosters,
+            validators: validators,
+            maxDataSize: MAX_DATA_SIZE,
+            nativeToken: address(0),
+            deployFactoriesToL2: true,
+            maxFeePerGasForRetryables: MAX_FEE_PER_GAS,
+            batchPosterManager: batchPosterManager,
+            feeTokenPricer: IFeeTokenPricer(address(0)),
+            customOsp: address(0)
+        });
+
+        rollupCreator.createRollup{value: factoryDeploymentFunds}(deployParams);
+
+        vm.stopPrank();
+
+        // The pre-existing balance must remain in the creator, not be refunded to the caller.
+        // Before the fix this is 0 (the whole balance was swept); after the fix it is `stray`.
+        assertEq(
+            address(rollupCreator).balance,
+            stray,
+            "pre-existing balance should stay in the creator, not be swept to the caller"
+        );
+    }
 }
 
 contract ProxyUpgradeAction {


### PR DESCRIPTION
### Summary

`RollupCreator._deployFactories` refunds the caller using the contract's **entire**
balance (`address(this).balance`) rather than the ETH that caller actually sent for
their own deployment. This changes it to refund only the caller's own contribution,
leaving any pre-existing balance untouched.

### Current behavior

```solidity
// refund the caller
(bool sent,) = msg.sender.call{value: address(this).balance}("");
require(sent, "Refund failed");
```

`RollupCreator` intentionally accepts ETH (`receive() external payable {}`) so the L2
factory deployer can return excess fees for the creator to refund. That part is by
design. The issue is only the refund amount: it sweeps the *whole* contract balance.

If any ETH is ever left in the contract — a stray transfer, dust from a prior
interaction, or a partial/failed deployment — the **next** caller of `createRollup`
receives it along with their own refund. The ETH goes to an unrelated address rather
than staying put or being recoverable by its sender.

### Impact

Low / hardening. In normal operation `RollupCreator` holds no ETH between transactions
(it's a stateless deployment factory), so there is no standing balance to misattribute
and no live exploit. This is a defense-in-depth fix: the refund should return what the
caller paid, not whatever happens to be sitting in the contract. It also removes a
foot-gun for anyone integrating with or forking the factory.

### Fix

Snapshot the balance that predates this call (everything above `msg.value`) and exclude
it from the refund. `msg.value` is still available inside the internal `_deployFactories`,
and no ETH leaves the contract before the refund line, so `preExistingBalance` correctly
captures only the stray balance.

### Compatibility

Non-breaking. In the normal path `preExistingBalance == 0`, so the caller receives the
exact same refund as before (their over-payment plus any excess returned by the factory
deployer). Behavior differs only when stray ETH was present — which is precisely the case
being fixed. No interface or storage-layout changes.

### Testing

Adds one regression test (`test_createRollup_refundExcludesPreExistingBalance`) that
force-sends ETH to the creator before `createRollup` and asserts the caller's refund does
not include it. All existing `RollupCreator` tests pass unchanged.