### PR TITLE
Pin the parent chain hash via ArbSys on an Arbitrum host chain

### DIFF
--- a/src/rollup/RollupAdminLogic.sol
+++ b/src/rollup/RollupAdminLogic.sol
@@ -74,7 +74,10 @@ contract RollupAdminLogic is RollupCore, IRollupAdmin, DoubleLogicUUPSUpgradeabl
             afterStateHash: config.genesisAssertionState.hash()
         });
 
-        bytes32 nextParentChainBlockHash = blockhash(block.number - 1);
+        // Must match createNewAssertion's: this pins the terminal the first post-genesis
+        // assertion has to extend from, and on an Arbitrum host chain blockhash() would pin
+        // an L1 hash that MEL's parentChainBlockHash can never equal.
+        bytes32 nextParentChainBlockHash = _nextParentChainBlockHash();
         AssertionNode memory initialAssertion = AssertionNodeLib.createAssertion(
             true,
             RollupLib.configHash({

--- a/src/rollup/RollupCore.sol
+++ b/src/rollup/RollupCore.sol
@@ -482,6 +482,15 @@ abstract contract RollupCore is IRollupCore, PausableUpgradeable {
         {
             // We want to prevent multiple assertions from being created in the same block, as this would allow them to have the same `nextParentChainBlockHash`,
             // which would be an already processed block hash by the time the assertions are created.
+            //
+            // On an Arbitrum host chain these are deliberately different units: block.number and
+            // createdAtBlock are L1 block numbers, while _nextParentChainBlockHash() advances with
+            // arbBlockNumber(). That is still sound, and in the safe direction. Every host block
+            // carries exactly one block.number, so two assertions in the same host block always
+            // see the same one and are rejected; many host blocks can share a block.number, so the
+            // check can only reject assertions whose hashes would in fact have differed. It over-
+            // rejects, never under-rejects. The cost is waiting for the next L1 block on a
+            // fast-block host, far below any real assertion cadence.
             require((block.number - prevAssertion.createdAtBlock) >= 1, "SAME_BLOCK_ASSERTION");
 
             // This new assertion consumes the messages from prevParentChainBlockHash to afterParentChainBlockHash

--- a/src/rollup/RollupCore.sol
+++ b/src/rollup/RollupCore.sol
@@ -416,6 +416,28 @@ abstract contract RollupCore is IRollupCore, PausableUpgradeable {
         delete _stakerMap[stakerAddress];
     }
 
+    /**
+     * @dev The parent chain block hash to pin as the terminal an assertion's child must
+     *      extend from. Compared against afterMELState.parentChainBlockHash when that child
+     *      is created, so it has to be a hash of *this* chain's parent chain.
+     *
+     *      On an Arbitrum host chain blockhash() resolves against the L1 block hash ring
+     *      buffer, so it would pin an L1 hash where MEL supplies a hash of the host chain's
+     *      parent, and the equality check could never pass. ArbSys gives the right one; a
+     *      single block back is well inside its 256-block window.
+     *
+     *      Used by both createNewAssertion and RollupAdminLogic.initialize — the genesis
+     *      assertion pins the terminal for the first post-genesis assertion, so both have to
+     *      agree or that first assertion cannot be created.
+     */
+    function _nextParentChainBlockHash() internal view returns (bytes32) {
+        if (_hostChainIsArbitrum) {
+            ArbSys arbSys = ArbSys(address(100));
+            return arbSys.arbBlockHash(arbSys.arbBlockNumber() - 1);
+        }
+        return blockhash(block.number - 1);
+    }
+
     function createNewAssertion(
         AssertionInputs calldata assertion,
         bytes32 prevAssertionHash,
@@ -506,18 +528,8 @@ abstract contract RollupCore is IRollupCore, PausableUpgradeable {
             "ASSERTION_SEEN"
         );
 
-        // Next assertion will have to process messages from blocks up to the previous one.
-        // On an Arbitrum host chain, blockhash() resolves against the L1 block hash ring
-        // buffer, so it would pin an L1 hash where afterMELState.parentChainBlockHash is a
-        // hash of this chain's parent -- the equality check above could never pass. ArbSys
-        // gives the parent chain hash; one block back is well inside its 256-block window.
-        bytes32 nextParentChainBlockHash;
-        if (_hostChainIsArbitrum) {
-            ArbSys arbSys = ArbSys(address(100));
-            nextParentChainBlockHash = arbSys.arbBlockHash(arbSys.arbBlockNumber() - 1);
-        } else {
-            nextParentChainBlockHash = blockhash(block.number - 1);
-        }
+        // Next assertion will have to process messages from blocks up to the previous one
+        bytes32 nextParentChainBlockHash = _nextParentChainBlockHash();
 
         // state updates
         AssertionNode memory newAssertion = AssertionNodeLib.createAssertion(

--- a/src/rollup/RollupCore.sol
+++ b/src/rollup/RollupCore.sol
@@ -506,8 +506,18 @@ abstract contract RollupCore is IRollupCore, PausableUpgradeable {
             "ASSERTION_SEEN"
         );
 
-        // Next assertion will have to process messages from blocks up to the previous one
-        bytes32 nextParentChainBlockHash = blockhash(block.number - 1);
+        // Next assertion will have to process messages from blocks up to the previous one.
+        // On an Arbitrum host chain, blockhash() resolves against the L1 block hash ring
+        // buffer, so it would pin an L1 hash where afterMELState.parentChainBlockHash is a
+        // hash of this chain's parent -- the equality check above could never pass. ArbSys
+        // gives the parent chain hash; one block back is well inside its 256-block window.
+        bytes32 nextParentChainBlockHash;
+        if (_hostChainIsArbitrum) {
+            ArbSys arbSys = ArbSys(address(100));
+            nextParentChainBlockHash = arbSys.arbBlockHash(arbSys.arbBlockNumber() - 1);
+        } else {
+            nextParentChainBlockHash = blockhash(block.number - 1);
+        }
 
         // state updates
         AssertionNode memory newAssertion = AssertionNodeLib.createAssertion(

--- a/test/foundry/RollupParentChainHash.t.sol
+++ b/test/foundry/RollupParentChainHash.t.sol
@@ -1,0 +1,71 @@
+// Copyright 2026, Offchain Labs, Inc.
+// For license information, see https://github.com/OffchainLabs/nitro-contracts/blob/main/LICENSE.md
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../../src/rollup/RollupAdminLogic.sol";
+import "../../src/precompiles/ArbSys.sol";
+
+/// Exposes the internal helper both createNewAssertion and RollupAdminLogic.initialize use to
+/// pin the terminal an assertion's child must extend from. RollupAdminLogic is concrete and
+/// inherits RollupCore's `_hostChainIsArbitrum` immutable, so deploying one is enough to
+/// exercise the branch without standing up a whole rollup.
+contract NextParentChainBlockHashHarness is RollupAdminLogic {
+    function exposedNextParentChainBlockHash() external view returns (bytes32) {
+        return _nextParentChainBlockHash();
+    }
+}
+
+contract RollupParentChainHashTest is Test {
+    uint256 constant ARB_BLOCK = 12_345;
+    bytes32 constant ARB_BLOCK_HASH = keccak256("arbBlockHash(12344)");
+
+    /// `_hostChainIsArbitrum` is an immutable initialized from ArbitrumChecker at construction,
+    /// so ArbSys has to answer before the harness is deployed, not after.
+    function _mockArbitrumHost() internal {
+        vm.mockCall(
+            address(100),
+            abi.encodeWithSelector(ArbSys.arbOSVersion.selector),
+            abi.encode(uint256(11))
+        );
+    }
+
+    function testUsesArbSysOnArbitrumHostChain() public {
+        _mockArbitrumHost();
+        NextParentChainBlockHashHarness harness = new NextParentChainBlockHashHarness();
+
+        vm.mockCall(
+            address(100),
+            abi.encodeWithSelector(ArbSys.arbBlockNumber.selector),
+            abi.encode(ARB_BLOCK)
+        );
+        vm.mockCall(
+            address(100),
+            abi.encodeWithSelector(ArbSys.arbBlockHash.selector, ARB_BLOCK - 1),
+            abi.encode(ARB_BLOCK_HASH)
+        );
+
+        assertEq(
+            harness.exposedNextParentChainBlockHash(),
+            ARB_BLOCK_HASH,
+            "must pin arbBlockHash(arbBlockNumber() - 1), not the L1 ring buffer"
+        );
+        // The bug this guards: blockhash() on an Arbitrum host resolves against the L1 ring
+        // buffer, so MEL's parentChainBlockHash could never equal it.
+        assertTrue(
+            harness.exposedNextParentChainBlockHash() != blockhash(block.number - 1),
+            "fixture must make the two sources differ, or this test proves nothing"
+        );
+    }
+
+    function testUsesBlockhashOffArbitrum() public {
+        NextParentChainBlockHashHarness harness = new NextParentChainBlockHashHarness();
+        assertEq(
+            harness.exposedNextParentChainBlockHash(),
+            blockhash(block.number - 1),
+            "off an Arbitrum host chain the terminal is still blockhash(block.number - 1)"
+        );
+    }
+}


### PR DESCRIPTION
`createNewAssertion` records the next assertion's terminal as:

```solidity
bytes32 nextParentChainBlockHash = blockhash(block.number - 1);
```

On an Arbitrum host chain `blockhash` resolves through `ProcessingHook.L1BlockHash` to ArbOS's **L1** block hash ring buffer, so this stores an L1 hash where `afterMELState.parentChainBlockHash` is a hash of this chain's own parent. The equality check twenty lines earlier then cannot pass:

```solidity
require(
    afterMELState.parentChainBlockHash
        == assertion.beforeStateData.configData.nextParentChainBlockHash,
    "BAD_PARENT_CHAIN_BLOCK_HASH"
);
```

**No L3 assertion satisfies that**, and because `block.number - 1` is inside the 256-block window it returns a plausible non-zero hash rather than reverting — so it fails silently.

### This is new code missing an established pattern, not a latent bug

The class of issue is well known here. `main` already has five `hostChainIsArbitrum` branches in `SequencerInbox.sol` and `_assertionCreatedAtArbSysBlock` in this very file, commented *"this will be the ArbSys blockNumber if the host chain is an Arbitrum chain."*

What's new is the call site. `blockhash(` does not appear anywhere in `src/` on `main` — this is the only use of it in the contracts, introduced with MEL, and it didn't take the branch the codebase takes everywhere else. The fix mirrors the pattern thirty lines below it in the same function.

`ArbSys.arbBlockHash` reverts only outside `currentBlockNum-256 <= n < currentBlockNum` (`precompiles/ArbSys.go`), so one block back is comfortably inside the window.

### Both terminals, not just one

`createNewAssertion` is the recurring case; `RollupAdminLogic.initialize` seeds the genesis assertion's terminal the same way. Fixing only the first leaves the very first L3 assertion unmatchable, so both go through the shared `_nextParentChainBlockHash` helper.

### Scope

Nothing in production is affected — none of `nextParentChainBlockHash`, `afterMELState` or `MELState` exists on `main`. On a non-Arbitrum host the `else` branch is the current code, so L1-parent chains are unchanged.

### Pairs with OffchainLabs/nitro-private#672

That one fixes MEL writing the parent chain block number where the Bridge hashed the L1 block number in delayed message headers.

**Both are needed before MEL works on an L3; neither is sufficient alone.** They can merge independently and in any order — each is a strict improvement and a no-op on L1 parents — but do not read either landing as "L3 fixed." nitro-private picks this up via a contracts submodule bump once this lands in the MEL stack.

### Base branch

Retargeted from `mel-bold-changes` to `feat/mel-validation-changes` (#427). `mel-bold-changes` is abandoned — its own PRs #436 and #438 were both closed unmerged and its tip has not moved since 2026-07-09, so nothing based on it could merge. #427 is where `SAME_BLOCK_ASSERTION` and the MEL assertion machinery this patches are introduced, which makes it the lowest point in the live stack that the fix belongs at.

That also cleared the `Check Contracts Format` failure. `src/osp/OneStepProofEntry.sol` had a line at 104 chars against `line_length = 100`, pushed over by one of the five OSP commits exclusive to the old base; on `feat/mel-validation-changes` it is exactly 100.

### Verification

`forge fmt --check` clean, `forge build` succeeds, and `FOUNDRY_PROFILE=test forge test --match-path test/foundry/RollupParentChainHash.t.sol` passes 2/2 on the new base.
